### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "79f776d01c734704c8578eb109d14844c2568600",
+  "baseline-sha": "e3678a8ace5786f303659e2fb8e49fa6bfe1a9e7",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.2.0",
-      "tag": "v0.2.0"
+      "version": "0.3.0",
+      "tag": "v0.3.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.2.0",
-      "tag": "v0.2.0"
+      "version": "0.3.0",
+      "tag": "v0.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/fatou/compare/v0.2.0...v0.3.0) (2026-07-01)
+
+### Features
+- **formatter:** empty-body inline fold for if/try/do ([`8912b64`](https://github.com/jolars/fatou/commit/8912b64b19c3a9fe8dd879627d099f6bd145acd2))
+- **formatter:** width-driven comparison and arrow ([`662331d`](https://github.com/jolars/fatou/commit/662331d5f33f2f7522784b65ee746bb4a565cfd9))
+- **formatter:** width-driven ternary reflow ([`58e5336`](https://github.com/jolars/fatou/commit/58e53364ad13270084eca4b7d50400d4b2ed6b48))
+- **formatter:** width-driven binary continuation ([`34c3e16`](https://github.com/jolars/fatou/commit/34c3e16a3b034b7449e9ee874c315c3288c82be1))
+- **formatter:** width-driven parenthesized reflow ([`3903b5f`](https://github.com/jolars/fatou/commit/3903b5fe9ad655c4092a65bddbbd2ee39e8c95fb))
+- **formatter:** reflow top-level semicolon joins ([`463c9de`](https://github.com/jolars/fatou/commit/463c9dec18cb67a93dc933678891090a20bb5970))
+- **formatter:** reflow top-level blank lines ([`e556bfd`](https://github.com/jolars/fatou/commit/e556bfd97b974ccb57e748d44f383a520bf7ce9a))
+- **formatter:** inline empty bodies across blocks ([`d61784f`](https://github.com/jolars/fatou/commit/d61784f5a0dca9721a35971b745355836e39f0fe))
+
 ## [0.2.0](https://github.com/jolars/fatou/compare/v0.1.0...v0.2.0) (2026-06-30)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -304,7 +304,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fatou"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -395,9 +395,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,40 +1,40 @@
 {
-	"name": "fatou-cli",
-	"version": "0.2.0",
-	"description": "A language server, formatter, and linter for Julia",
-	"keywords": [
-		"julia",
-		"language-server",
-		"formatter",
-		"linter"
-	],
-	"homepage": "https://github.com/jolars/fatou",
-	"bugs": "https://github.com/jolars/fatou/issues",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/jolars/fatou.git"
-	},
-	"license": "MIT",
-	"author": "Johan Larsson <johan@jolars.co>",
-	"bin": {
-		"fatou": "bin/fatou.js"
-	},
-	"files": [
-		"bin/",
-		"README.md",
-		"LICENSE"
-	],
-	"engines": {
-		"node": ">=20"
-	},
-	"optionalDependencies": {
-		"@fatou-cli/linux-x64-gnu": "0.2.0",
-		"@fatou-cli/linux-arm64-gnu": "0.2.0",
-		"@fatou-cli/linux-x64-musl": "0.2.0",
-		"@fatou-cli/linux-arm64-musl": "0.2.0",
-		"@fatou-cli/darwin-x64": "0.2.0",
-		"@fatou-cli/darwin-arm64": "0.2.0",
-		"@fatou-cli/win32-x64": "0.2.0",
-		"@fatou-cli/win32-arm64": "0.2.0"
-	}
+  "name": "fatou-cli",
+  "version": "0.3.0",
+  "description": "A language server, formatter, and linter for Julia",
+  "keywords": [
+    "julia",
+    "language-server",
+    "formatter",
+    "linter"
+  ],
+  "homepage": "https://github.com/jolars/fatou",
+  "bugs": "https://github.com/jolars/fatou/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jolars/fatou.git"
+  },
+  "license": "MIT",
+  "author": "Johan Larsson <johan@jolars.co>",
+  "bin": {
+    "fatou": "bin/fatou.js"
+  },
+  "files": [
+    "bin/",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "optionalDependencies": {
+    "@fatou-cli/linux-x64-gnu": "0.3.0",
+    "@fatou-cli/linux-arm64-gnu": "0.3.0",
+    "@fatou-cli/linux-x64-musl": "0.3.0",
+    "@fatou-cli/linux-arm64-musl": "0.3.0",
+    "@fatou-cli/darwin-x64": "0.3.0",
+    "@fatou-cli/darwin-arm64": "0.3.0",
+    "@fatou-cli/win32-x64": "0.3.0",
+    "@fatou-cli/win32-arm64": "0.3.0"
+  }
 }


### PR DESCRIPTION
## [0.3.0](https://github.com/jolars/fatou/compare/v0.2.0...v0.3.0) (2026-07-01)

### Features
- **formatter:** empty-body inline fold for if/try/do ([`8912b64`](https://github.com/jolars/fatou/commit/8912b64b19c3a9fe8dd879627d099f6bd145acd2))
- **formatter:** width-driven comparison and arrow ([`662331d`](https://github.com/jolars/fatou/commit/662331d5f33f2f7522784b65ee746bb4a565cfd9))
- **formatter:** width-driven ternary reflow ([`58e5336`](https://github.com/jolars/fatou/commit/58e53364ad13270084eca4b7d50400d4b2ed6b48))
- **formatter:** width-driven binary continuation ([`34c3e16`](https://github.com/jolars/fatou/commit/34c3e16a3b034b7449e9ee874c315c3288c82be1))
- **formatter:** width-driven parenthesized reflow ([`3903b5f`](https://github.com/jolars/fatou/commit/3903b5fe9ad655c4092a65bddbbd2ee39e8c95fb))
- **formatter:** reflow top-level semicolon joins ([`463c9de`](https://github.com/jolars/fatou/commit/463c9dec18cb67a93dc933678891090a20bb5970))
- **formatter:** reflow top-level blank lines ([`e556bfd`](https://github.com/jolars/fatou/commit/e556bfd97b974ccb57e748d44f383a520bf7ce9a))
- **formatter:** inline empty bodies across blocks ([`d61784f`](https://github.com/jolars/fatou/commit/d61784f5a0dca9721a35971b745355836e39f0fe))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).