### PR TITLE
chore(release): v0.4.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
-	"manifest-version": 1,
-	"baseline-sha": "e3678a8ace5786f303659e2fb8e49fa6bfe1a9e7",
-	"release-targets": [
-		{
-			"path": ".",
-			"version": "0.3.0",
-			"tag": "v0.3.0"
-		},
-		{
-			"path": "editors/code",
-			"version": "0.3.0",
-			"tag": "fatou-code-v0.3.0"
-		}
-	],
-	"pending-release-targets": [
-		{
-			"path": ".",
-			"version": "0.3.0",
-			"tag": "v0.3.0"
-		},
-		{
-			"path": "editors/code",
-			"version": "0.3.0",
-			"tag": "fatou-code-v0.3.0"
-		}
-	]
+  "manifest-version": 1,
+  "baseline-sha": "c9af19bcb13f097fe149720041475c7947f9cceb",
+  "release-targets": [
+    {
+      "path": ".",
+      "version": "0.4.0",
+      "tag": "v0.4.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "0.4.0",
+      "tag": "fatou-code-v0.4.0"
+    }
+  ],
+  "pending-release-targets": [
+    {
+      "path": ".",
+      "version": "0.4.0",
+      "tag": "v0.4.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "0.4.0",
+      "tag": "fatou-code-v0.4.0"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/fatou/compare/v0.3.0...v0.4.0) (2026-07-02)
+
+### Features
+- add VSCODE and OSVX extensions ([`c9af19b`](https://github.com/jolars/fatou/commit/c9af19bcb13f097fe149720041475c7947f9cceb))
+- **formatter:** width-driven paren-block break ([`5905ed2`](https://github.com/jolars/fatou/commit/5905ed2554eaf4a9559182b8190f74e6a5c9e8a6))
+- **formatter:** break the semicolon keyword tail ([`7d33a5b`](https://github.com/jolars/fatou/commit/7d33a5bf2750e4229b6940b7d25227083e14d9fe))
+- **formatter:** reflow source-multiline comprehensions ([`cbeaa25`](https://github.com/jolars/fatou/commit/cbeaa252de4e5b54c131d5fdfc1e31340cb8cbe9))
+- **formatter:** reflow comprehensions and generators ([`deb0df3`](https://github.com/jolars/fatou/commit/deb0df3520f7571887144dae5fe900f73d8e1259))
+- **formatter:** snug unary prefix operators ([`d04276d`](https://github.com/jolars/fatou/commit/d04276dd980dbf464c5991b52583d8a8f90a81ae))
+- **formatter:** normalize macro-call spacing ([`f0fdd0a`](https://github.com/jolars/fatou/commit/f0fdd0aa17d670810cb72e01c1d9d2f66b3dc6e0))
+- **formatter:** normalize type-decl whitespace ([`b62b197`](https://github.com/jolars/fatou/commit/b62b19791e8c3779204d005eac459ab3ee681896))
+- **cli:** add manpages and completion ([`f1b9866`](https://github.com/jolars/fatou/commit/f1b986618943dc8dc8cc4283f000fb2575a186f7))
+
 ## [0.3.0](https://github.com/jolars/fatou/compare/v0.2.0...v0.3.0) (2026-07-01)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fatou"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/fatou/compare/fatou-code-v0.3.0...fatou-code-v0.4.0) (2026-07-02)
+
+### Features
+- add VSCODE and OSVX extensions ([`c9af19b`](https://github.com/jolars/fatou/commit/c9af19bcb13f097fe149720041475c7947f9cceb))
+
+### Dependencies
+- updated fatou to v0.4.0
+
 All notable changes to the Fatou VS Code extension are documented here.
 
 ## 0.3.0

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1,186 +1,186 @@
 {
-	"name": "fatou",
-	"displayName": "Fatou",
-	"description": "Julia language server, formatter, and linter",
-	"version": "0.3.0",
-	"publisher": "jolars",
-	"license": "MIT",
-	"icon": "icon.png",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/jolars/fatou.git"
-	},
-	"homepage": "https://github.com/jolars/fatou",
-	"bugs": {
-		"url": "https://github.com/jolars/fatou/issues"
-	},
-	"engines": {
-		"vscode": "^1.91.0"
-	},
-	"categories": [
-		"Formatters",
-		"Linters",
-		"Programming Languages"
-	],
-	"keywords": [
-		"julia",
-		"formatter",
-		"linter",
-		"language-server"
-	],
-	"activationEvents": [
-		"onLanguage:julia",
-		"workspaceContains:**/*.jl",
-		"workspaceContains:fatou.toml",
-		"workspaceContains:.fatou.toml",
-		"workspaceContains:Project.toml",
-		"workspaceContains:JuliaProject.toml"
-	],
-	"main": "./dist/extension.js",
-	"contributes": {
-		"languages": [
-			{
-				"id": "julia",
-				"extensions": [
-					".jl"
-				],
-				"aliases": [
-					"Julia",
-					"julia"
-				]
-			}
-		],
-		"configuration": {
-			"title": "Fatou",
-			"properties": {
-				"fatou.executableStrategy": {
-					"type": "string",
-					"enum": [
-						"bundled",
-						"environment",
-						"path"
-					],
-					"enumDescriptions": [
-						"Use the binary bundled inside the extension; fall back to downloading from GitHub if none is bundled or `fatou.version`/`fatou.releaseTag` is set explicitly (default).",
-						"Look for `fatou` on the system PATH.",
-						"Use the binary at `fatou.executablePath`."
-					],
-					"default": "bundled",
-					"markdownDescription": "Strategy used to locate the `fatou` executable for the language server."
-				},
-				"fatou.executablePath": {
-					"type": [
-						"string",
-						"null"
-					],
-					"default": null,
-					"markdownDescription": "Path to the `fatou` executable. Only used when `fatou.executableStrategy` is set to `path`."
-				},
-				"fatou.version": {
-					"type": "string",
-					"default": "latest",
-					"description": "Fatou version to install (for example: latest or 0.2.0)."
-				},
-				"fatou.releaseTag": {
-					"type": "string",
-					"default": "latest",
-					"description": "Advanced override for the exact GitHub release tag (for example: v0.2.0). If explicitly set, this takes precedence over fatou.version."
-				},
-				"fatou.githubRepo": {
-					"type": "string",
-					"default": "jolars/fatou",
-					"description": "GitHub repository used for Fatou binary downloads (<owner>/<repo>)."
-				},
-				"fatou.serverArgs": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"default": [],
-					"description": "Additional command-line arguments passed after `fatou lsp`."
-				},
-				"fatou.serverEnv": {
-					"type": "object",
-					"additionalProperties": {
-						"type": "string"
-					},
-					"default": {},
-					"description": "Environment variables merged into the Fatou language server process."
-				},
-				"fatou.extraPath": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"default": [],
-					"description": "Extra PATH entries prepended for the Fatou language server process."
-				},
-				"fatou.logLevel": {
-					"type": [
-						"string",
-						"null"
-					],
-					"enum": [
-						null,
-						"off",
-						"error",
-						"warn",
-						"info",
-						"debug",
-						"trace"
-					],
-					"default": null,
-					"markdownDescription": "Log level for the Fatou language server. Maps to the `RUST_LOG` environment variable. Leave unset to use the server's default. If `fatou.serverEnv.RUST_LOG` is also set, it takes precedence."
-				},
-				"fatou.trace.server": {
-					"type": "string",
-					"enum": [
-						"off",
-						"messages",
-						"verbose"
-					],
-					"default": "off",
-					"description": "Trace communication between VS Code and the Fatou language server."
-				}
-			}
-		},
-		"configurationDefaults": {
-			"[julia]": {
-				"editor.defaultFormatter": "jolars.fatou"
-			}
-		},
-		"commands": [
-			{
-				"command": "fatou.restart",
-				"title": "Restart Server",
-				"category": "Fatou"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run clean && npm run check-types && npm run bundle:prod",
-		"compile": "npm run clean && npm run check-types && npm run bundle",
-		"clean": "rm -rf dist",
-		"check-types": "tsc --noEmit -p .",
-		"bundle": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --sourcemap --external:vscode --outfile=dist/extension.js",
-		"bundle:prod": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --minify --external:vscode --outfile=dist/extension.js",
-		"watch": "npm-run-all -p watch:esbuild watch:tsc",
-		"watch:esbuild": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --sourcemap --watch --external:vscode --outfile=dist/extension.js",
-		"watch:tsc": "tsc --noEmit -w -p .",
-		"package": "vsce package"
-	},
-	"dependencies": {
-		"adm-zip": "^0.5.17",
-		"tar": "^7.5.16",
-		"vscode-languageclient": "^10.0.0"
-	},
-	"devDependencies": {
-		"@types/adm-zip": "^0.5.8",
-		"@types/node": "^25.9.2",
-		"@types/vscode": "^1.91.0",
-		"@vscode/vsce": "^3.9.2",
-		"esbuild": "^0.28.0",
-		"npm-run-all": "^4.1.5",
-		"typescript": "^6.0.3"
-	}
+  "name": "fatou",
+  "displayName": "Fatou",
+  "description": "Julia language server, formatter, and linter",
+  "version": "0.4.0",
+  "publisher": "jolars",
+  "license": "MIT",
+  "icon": "icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jolars/fatou.git"
+  },
+  "homepage": "https://github.com/jolars/fatou",
+  "bugs": {
+    "url": "https://github.com/jolars/fatou/issues"
+  },
+  "engines": {
+    "vscode": "^1.91.0"
+  },
+  "categories": [
+    "Formatters",
+    "Linters",
+    "Programming Languages"
+  ],
+  "keywords": [
+    "julia",
+    "formatter",
+    "linter",
+    "language-server"
+  ],
+  "activationEvents": [
+    "onLanguage:julia",
+    "workspaceContains:**/*.jl",
+    "workspaceContains:fatou.toml",
+    "workspaceContains:.fatou.toml",
+    "workspaceContains:Project.toml",
+    "workspaceContains:JuliaProject.toml"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "julia",
+        "extensions": [
+          ".jl"
+        ],
+        "aliases": [
+          "Julia",
+          "julia"
+        ]
+      }
+    ],
+    "configuration": {
+      "title": "Fatou",
+      "properties": {
+        "fatou.executableStrategy": {
+          "type": "string",
+          "enum": [
+            "bundled",
+            "environment",
+            "path"
+          ],
+          "enumDescriptions": [
+            "Use the binary bundled inside the extension; fall back to downloading from GitHub if none is bundled or `fatou.version`/`fatou.releaseTag` is set explicitly (default).",
+            "Look for `fatou` on the system PATH.",
+            "Use the binary at `fatou.executablePath`."
+          ],
+          "default": "bundled",
+          "markdownDescription": "Strategy used to locate the `fatou` executable for the language server."
+        },
+        "fatou.executablePath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Path to the `fatou` executable. Only used when `fatou.executableStrategy` is set to `path`."
+        },
+        "fatou.version": {
+          "type": "string",
+          "default": "latest",
+          "description": "Fatou version to install (for example: latest or 0.2.0)."
+        },
+        "fatou.releaseTag": {
+          "type": "string",
+          "default": "latest",
+          "description": "Advanced override for the exact GitHub release tag (for example: v0.2.0). If explicitly set, this takes precedence over fatou.version."
+        },
+        "fatou.githubRepo": {
+          "type": "string",
+          "default": "jolars/fatou",
+          "description": "GitHub repository used for Fatou binary downloads (<owner>/<repo>)."
+        },
+        "fatou.serverArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional command-line arguments passed after `fatou lsp`."
+        },
+        "fatou.serverEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Environment variables merged into the Fatou language server process."
+        },
+        "fatou.extraPath": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra PATH entries prepended for the Fatou language server process."
+        },
+        "fatou.logLevel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "default": null,
+          "markdownDescription": "Log level for the Fatou language server. Maps to the `RUST_LOG` environment variable. Leave unset to use the server's default. If `fatou.serverEnv.RUST_LOG` is also set, it takes precedence."
+        },
+        "fatou.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Trace communication between VS Code and the Fatou language server."
+        }
+      }
+    },
+    "configurationDefaults": {
+      "[julia]": {
+        "editor.defaultFormatter": "jolars.fatou"
+      }
+    },
+    "commands": [
+      {
+        "command": "fatou.restart",
+        "title": "Restart Server",
+        "category": "Fatou"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run clean && npm run check-types && npm run bundle:prod",
+    "compile": "npm run clean && npm run check-types && npm run bundle",
+    "clean": "rm -rf dist",
+    "check-types": "tsc --noEmit -p .",
+    "bundle": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --sourcemap --external:vscode --outfile=dist/extension.js",
+    "bundle:prod": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --minify --external:vscode --outfile=dist/extension.js",
+    "watch": "npm-run-all -p watch:esbuild watch:tsc",
+    "watch:esbuild": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --sourcemap --watch --external:vscode --outfile=dist/extension.js",
+    "watch:tsc": "tsc --noEmit -w -p .",
+    "package": "vsce package"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.17",
+    "tar": "^7.5.16",
+    "vscode-languageclient": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
+    "@types/node": "^25.9.2",
+    "@types/vscode": "^1.91.0",
+    "@vscode/vsce": "^3.9.2",
+    "esbuild": "^0.28.0",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^6.0.3"
+  }
 }

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.3.0",
-    "@fatou-cli/linux-arm64-gnu": "0.3.0",
-    "@fatou-cli/linux-x64-musl": "0.3.0",
-    "@fatou-cli/linux-arm64-musl": "0.3.0",
-    "@fatou-cli/darwin-x64": "0.3.0",
-    "@fatou-cli/darwin-arm64": "0.3.0",
-    "@fatou-cli/win32-x64": "0.3.0",
-    "@fatou-cli/win32-arm64": "0.3.0"
+    "@fatou-cli/linux-x64-gnu": "0.4.0",
+    "@fatou-cli/linux-arm64-gnu": "0.4.0",
+    "@fatou-cli/linux-x64-musl": "0.4.0",
+    "@fatou-cli/linux-arm64-musl": "0.4.0",
+    "@fatou-cli/darwin-x64": "0.4.0",
+    "@fatou-cli/darwin-arm64": "0.4.0",
+    "@fatou-cli/win32-x64": "0.4.0",
+    "@fatou-cli/win32-arm64": "0.4.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.4.0](https://github.com/jolars/fatou/compare/v0.3.0...v0.4.0) (2026-07-02)

### Features
- add VSCODE and OSVX extensions ([`c9af19b`](https://github.com/jolars/fatou/commit/c9af19bcb13f097fe149720041475c7947f9cceb))
- **formatter:** width-driven paren-block break ([`5905ed2`](https://github.com/jolars/fatou/commit/5905ed2554eaf4a9559182b8190f74e6a5c9e8a6))
- **formatter:** break the semicolon keyword tail ([`7d33a5b`](https://github.com/jolars/fatou/commit/7d33a5bf2750e4229b6940b7d25227083e14d9fe))
- **formatter:** reflow source-multiline comprehensions ([`cbeaa25`](https://github.com/jolars/fatou/commit/cbeaa252de4e5b54c131d5fdfc1e31340cb8cbe9))
- **formatter:** reflow comprehensions and generators ([`deb0df3`](https://github.com/jolars/fatou/commit/deb0df3520f7571887144dae5fe900f73d8e1259))
- **formatter:** snug unary prefix operators ([`d04276d`](https://github.com/jolars/fatou/commit/d04276dd980dbf464c5991b52583d8a8f90a81ae))
- **formatter:** normalize macro-call spacing ([`f0fdd0a`](https://github.com/jolars/fatou/commit/f0fdd0aa17d670810cb72e01c1d9d2f66b3dc6e0))
- **formatter:** normalize type-decl whitespace ([`b62b197`](https://github.com/jolars/fatou/commit/b62b19791e8c3779204d005eac459ab3ee681896))
- **cli:** add manpages and completion ([`f1b9866`](https://github.com/jolars/fatou/commit/f1b986618943dc8dc8cc4283f000fb2575a186f7))

## [editors/code: 0.4.0](https://github.com/jolars/fatou/compare/fatou-code-v0.3.0...fatou-code-v0.4.0) (2026-07-02)

### Features
- add VSCODE and OSVX extensions ([`c9af19b`](https://github.com/jolars/fatou/commit/c9af19bcb13f097fe149720041475c7947f9cceb))

### Dependencies
- updated fatou to v0.4.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).