### PR TITLE
chore(release): v0.7.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "e5358e2fa101fa74b5d8deddfb2248ada420cf32",
+  "baseline-sha": "766dc0fbe7038f265086d3c1a56b5e4336ba564c",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.6.0",
-      "tag": "v0.6.0"
+      "version": "0.7.0",
+      "tag": "v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.6.0",
-      "tag": "fatou-code-v0.6.0"
+      "version": "0.7.0",
+      "tag": "fatou-code-v0.7.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.6.0",
-      "tag": "v0.6.0"
+      "version": "0.7.0",
+      "tag": "v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.6.0",
-      "tag": "fatou-code-v0.6.0"
+      "version": "0.7.0",
+      "tag": "fatou-code-v0.7.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/fatou/compare/v0.6.0...v0.7.0) (2026-07-25)
+
+### Features
+- add `exclude` config and `--force-exclude` ([`973972b`](https://github.com/jolars/fatou/commit/973972b324cc00d3d83546f7b5fd3e64c1fb5038))
+- **lint:** add `redefined-constant` ([`918bbb6`](https://github.com/jolars/fatou/commit/918bbb6c86199df156d21801fc6fc85d3dbfefbd))
+- **lint:** add `call-arity` ([`856dd87`](https://github.com/jolars/fatou/commit/856dd87f062943aa04727be9201b559f27667a14))
+- **lint:** add `missing-include-file` and `include-cycle` ([`b8daf2e`](https://github.com/jolars/fatou/commit/b8daf2e4a02d4fd59a94f2c428707524eeab48a7))
+- **lsp:** merge workspace extensions into qualified hover ([`2d19656`](https://github.com/jolars/fatou/commit/2d19656341ba6cb17603fdace017cd9a0c60f00a))
+- **lsp:** surface workspace method extensions in navigation ([`61f1e83`](https://github.com/jolars/fatou/commit/61f1e83c23db966f9940f7a6921c67713e8e4e5c))
+
+### Bug Fixes
+- guard force-exclude paths by `has_root` ([`766dc0f`](https://github.com/jolars/fatou/commit/766dc0fbe7038f265086d3c1a56b5e4336ba564c))
+- **deps:** bump `brace-expansion` to patched versions ([`86222e2`](https://github.com/jolars/fatou/commit/86222e2687c43d974ccbd7214f83eff848b35aae))
+
 ## [0.6.0](https://github.com/jolars/fatou/compare/v0.5.0...v0.6.0) (2026-07-20)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -173,14 +173,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -364,7 +364,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -822,9 +822,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ad5919b18c2deaf18921fffd5c84d6e41416d1ef80b6b541d629aa30ce8556"
+checksum = "a14fdadbf856222e731756d7fdbdf193a7abf8fdab009bb45f48671a42719a84"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -848,15 +848,15 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50068b1f8b1ac7567a4a70eb6cc15daa9dc997b73a6b5aa3248dd960755cddb"
+checksum = "50d7dc08ba69b9aedfa61dfc4d65548ae42c0d8b90bbd62cd121776920841bcf"
 
 [[package]]
 name = "salsa-macros"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26cb1c61fc424f7ff36e0606491429f58d1738bb0917cd999d680baae0c52c"
+checksum = "ec5c48c5a4a53a6e2be9762f56566f1325d4394c011c00b3ea86ba2d13411e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -905,7 +905,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1042,7 +1042,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/fatou/compare/fatou-code-v0.6.0...fatou-code-v0.7.0) (2026-07-25)
+
+### Bug Fixes
+- **deps:** bump `brace-expansion` to patched versions ([`86222e2`](https://github.com/jolars/fatou/commit/86222e2687c43d974ccbd7214f83eff848b35aae))
+
+### Dependencies
+- updated fatou to v0.7.0
+
 ## [0.6.0](https://github.com/jolars/fatou/compare/fatou-code-v0.5.0...fatou-code-v0.6.0) (2026-07-20)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.6.0",
-    "@fatou-cli/linux-arm64-gnu": "0.6.0",
-    "@fatou-cli/linux-x64-musl": "0.6.0",
-    "@fatou-cli/linux-arm64-musl": "0.6.0",
-    "@fatou-cli/darwin-x64": "0.6.0",
-    "@fatou-cli/darwin-arm64": "0.6.0",
-    "@fatou-cli/win32-x64": "0.6.0",
-    "@fatou-cli/win32-arm64": "0.6.0"
+    "@fatou-cli/linux-x64-gnu": "0.7.0",
+    "@fatou-cli/linux-arm64-gnu": "0.7.0",
+    "@fatou-cli/linux-x64-musl": "0.7.0",
+    "@fatou-cli/linux-arm64-musl": "0.7.0",
+    "@fatou-cli/darwin-x64": "0.7.0",
+    "@fatou-cli/darwin-arm64": "0.7.0",
+    "@fatou-cli/win32-x64": "0.7.0",
+    "@fatou-cli/win32-arm64": "0.7.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.7.0](https://github.com/jolars/fatou/compare/v0.6.0...v0.7.0) (2026-07-25)

### Features
- add `exclude` config and `--force-exclude` ([`973972b`](https://github.com/jolars/fatou/commit/973972b324cc00d3d83546f7b5fd3e64c1fb5038))
- **lint:** add `redefined-constant` ([`918bbb6`](https://github.com/jolars/fatou/commit/918bbb6c86199df156d21801fc6fc85d3dbfefbd))
- **lint:** add `call-arity` ([`856dd87`](https://github.com/jolars/fatou/commit/856dd87f062943aa04727be9201b559f27667a14))
- **lint:** add `missing-include-file` and `include-cycle` ([`b8daf2e`](https://github.com/jolars/fatou/commit/b8daf2e4a02d4fd59a94f2c428707524eeab48a7))
- **lsp:** merge workspace extensions into qualified hover ([`2d19656`](https://github.com/jolars/fatou/commit/2d19656341ba6cb17603fdace017cd9a0c60f00a))
- **lsp:** surface workspace method extensions in navigation ([`61f1e83`](https://github.com/jolars/fatou/commit/61f1e83c23db966f9940f7a6921c67713e8e4e5c))

### Bug Fixes
- guard force-exclude paths by `has_root` ([`766dc0f`](https://github.com/jolars/fatou/commit/766dc0fbe7038f265086d3c1a56b5e4336ba564c))
- **deps:** bump `brace-expansion` to patched versions ([`86222e2`](https://github.com/jolars/fatou/commit/86222e2687c43d974ccbd7214f83eff848b35aae))

## [editors/code: 0.7.0](https://github.com/jolars/fatou/compare/fatou-code-v0.6.0...fatou-code-v0.7.0) (2026-07-25)

### Bug Fixes
- **deps:** bump `brace-expansion` to patched versions ([`86222e2`](https://github.com/jolars/fatou/commit/86222e2687c43d974ccbd7214f83eff848b35aae))

### Dependencies
- updated fatou to v0.7.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).