### PR TITLE
fix(parser): skip a block comment before a header

### DIFF
--- a/.claude/skills/parser-parity/RECAP.md
+++ b/.claude/skills/parser-parity/RECAP.md
@@ -114,7 +114,7 @@ in either corpus).
 ## Progress
 
 JS corpus (**685 cases**—error shapes now harvested): **677 allowlisted**,
-8 divergence, 0 unsupported. Dir corpus: **213 allowlisted**, 1 blocked
+8 divergence, 0 unsupported. Dir corpus: **219 allowlisted**, 1 blocked
 (numeric_literals; FAIL not skip since `render` is total).
 Grammar bullets through "flat comparison chains" are `[x]` in `TODO.md`. **Error shapes are now reconstructed from diagnostics, not in-tree
 marker nodes** (2026-06-23i refactor)—same projected output, so counts
@@ -134,7 +134,48 @@ chains `a isa b isa c`/mixed `a < b isa c` (separate `word_operator` branch,
 stay nested). Plan `~/.claude/plans/yes-let-s-do-it-ticklish-deer.md` fully
 executed.
 
-## Latest session (2026-07-27b—lambda arrow `->` precedence)
+## Latest session (2026-07-28—a block comment after a block keyword swallowed the header)
+
+Issue #42. `skip_ws` does not cross comments, so every "header starts after the
+keyword" site landed on a `#= … =#` token instead of the header. `header_ends`
+correctly does *not* list `BlockComment` (a real header can follow one — that is
+the opposite of #26's line-comment fix), so the header opened anyway, `parse_expr`
+returned `None` at the comment, and the header expression fell through into the
+body block. `let` did this **silently** (a binding moved out of `LET_BINDINGS` —
+a scoping change); `if`/`while`/`elseif` also raised a spurious
+`expected a condition`, so those files failed `debug format` with `format-error`.
+
+Root cause is one cursor helper, so the fix is one helper + swaps at the header
+sites; nothing in `sexpr.rs`.
+
+- **`cursor::skip_ws_and_block_comments`** (+ `ParserCtx` method): whitespace and
+  `BlockComment` only. A block comment's own newlines ride along — Julia does not
+  end the header at a multi-line `#= … =#` either (`let #=\nc\n=# x = 1` ⇒
+  `(let (block (= x 1)) (block))`). A **line** comment stays a terminator.
+- **Swapped in** at every header-start site: `parse_header` (let/for),
+  `parse_condition` (if/elseif/while), `parse_signature` (struct/module),
+  `parse_do_params` (do), the `catch` exception variable, and
+  `parse_keyword_stmt`'s operand (return/const/global/local) — plus the two
+  comma lookaheads that continue a header list (`let x = 1 #= c =#, y = 2`,
+  `f() do x #= c =#, y`).
+- **`parse_function_like`** already crossed newlines (`function\n f() end`), so it
+  moved from `skip_ws_and_newlines` to the full `skip_trivia`: the signature is
+  never empty, so no comment there can end it. That also fixes the line-comment
+  sibling `function # c\n f() end` ⇒ `(function (call f) (block))`.
+- **Trivia placement**: the comment is emitted before the `Start(node)` event, so
+  it sits as a sibling of the header node, exactly like the whitespace around it.
+  `for` was already correct via `parse_for_specs`; its comment just moves out of
+  `FOR_BINDING`. Formatter output is unchanged and `debug format` stays green.
+- **Verified**: 33 probe cases (10 keyword forms × comment positions) now match
+  JuliaSyntax byte-for-byte, all lossless.
+- **Fixtures**: parser snapshot + oracle dir slug `keyword_header_block_comment`.
+- **Counts**: JS 677 (held, same 8 permanent FAILs, zero regressions);
+  dir 218 → **219**.
+- **Next**: no queued parser target. `else #= c =# if x` still takes the plain
+  `else` path rather than the `else if` recovery — left alone deliberately, error
+  shapes are a separate phase. Keep batch-probing real-world Julia.
+
+## Earlier session (2026-07-27b—lambda arrow `->` precedence)
 
 Batch-probed real-world Julia against the oracle (no queued target; the two
 2026-07-27 deferred items—`x.function` field name, `end` in a nested `[…]` within

--- a/src/parser/context.rs
+++ b/src/parser/context.rs
@@ -24,6 +24,10 @@ impl<'a> ParserCtx<'a> {
         cursor::skip_ws(self.tokens, i)
     }
 
+    pub(crate) fn skip_ws_and_block_comments(&self, i: usize) -> usize {
+        cursor::skip_ws_and_block_comments(self.tokens, i)
+    }
+
     pub(crate) fn skip_ws_and_newlines(&self, i: usize) -> usize {
         cursor::skip_ws_and_newlines(self.tokens, i)
     }

--- a/src/parser/cursor.rs
+++ b/src/parser/cursor.rs
@@ -8,6 +8,21 @@ pub(crate) fn skip_ws(tokens: &[Token], mut i: usize) -> usize {
     i
 }
 
+/// Skip horizontal whitespace and `#= … =#` block comments. A block comment on a
+/// keyword's line is trivia the header sits behind (`let #= c =# x = 1`), unlike
+/// a line comment, which runs to the end of the line and so genuinely ends the
+/// header. The comment's own newlines are skipped with it, since a multi-line
+/// `#= … =#` does not terminate the header either.
+pub(crate) fn skip_ws_and_block_comments(tokens: &[Token], mut i: usize) -> usize {
+    while matches!(
+        tokens.get(i).map(|t| t.kind),
+        Some(TokKind::Whitespace | TokKind::BlockComment)
+    ) {
+        i += 1;
+    }
+    i
+}
+
 /// Skip whitespace and newlines.
 pub(crate) fn skip_ws_and_newlines(tokens: &[Token], mut i: usize) -> usize {
     while matches!(

--- a/src/parser/structural.rs
+++ b/src/parser/structural.rs
@@ -127,8 +127,10 @@ fn parse_function_like(
     // bare annotation and a trailing `where` binds the whole signature (rather
     // than the return type), so parse it with `no_decl_where`. A newline between
     // the keyword and the signature is insignificant (`function\n f() end` ⇒
-    // `(function (call f) (block))`), so skip newlines too.
-    let sig_start = ctx.skip_ws_and_newlines(start + 1);
+    // `(function (call f) (block))`), and so is a comment (`function # c\n f()
+    // end`) — the signature is never empty, so nothing here can end it. Skip all
+    // trivia.
+    let sig_start = ctx.skip_trivia(start + 1);
     let mut i = if let Some(sig) = parse_signature_expr(tokens, sig_start, diagnostics) {
         push_range(&mut events, start + 1, sig.start);
         events.push(Event::Start(SyntaxKind::SIGNATURE));
@@ -306,7 +308,7 @@ pub(crate) fn parse_try_expr(
                 events.push(Event::Start(SyntaxKind::CATCH_CLAUSE));
                 events.push(Event::Tok(i));
                 // Optional exception variable on the `catch` line (`catch e`).
-                let var_start = ctx.skip_ws(i + 1);
+                let var_start = ctx.skip_ws_and_block_comments(i + 1);
                 push_range(&mut events, i + 1, var_start);
                 let mut j = var_start;
                 if !header_ends(&ctx, var_start)
@@ -584,7 +586,7 @@ pub(crate) fn parse_keyword_stmt(
 
     let mut i = start + 1;
     if !matches!(body, KwStmt::Bare) {
-        let operand_start = ctx.skip_ws(i);
+        let operand_start = ctx.skip_ws_and_block_comments(i);
         // A keyword whose value is optional (`return`) ends right after the
         // keyword when its operand position is a stray closing delimiter
         // (`return)`, `return ]`): the empty form `(return)` is emitted and the
@@ -1327,7 +1329,7 @@ fn parse_do_params(
     after_kw: usize,
     diagnostics: &mut Vec<ParseDiagnostic>,
 ) -> usize {
-    let start = ctx.skip_ws(after_kw);
+    let start = ctx.skip_ws_and_block_comments(after_kw);
     push_range(events, after_kw, start);
 
     if header_ends(ctx, start) {
@@ -1344,12 +1346,12 @@ fn parse_do_params(
     };
     // Continue the list only across commas; the first non-comma ends the args.
     loop {
-        let next = ctx.skip_ws(i);
+        let next = ctx.skip_ws_and_block_comments(i);
         if ctx.token(next).map(|t| t.kind) != Some(TokKind::Comma) {
             break;
         }
         push_range(events, i, next + 1);
-        let arg_start = ctx.skip_ws(next + 1);
+        let arg_start = ctx.skip_ws_and_block_comments(next + 1);
         push_range(events, next + 1, arg_start);
         match parse_expr(ctx.tokens(), arg_start, 0, diagnostics) {
             Some(expr) => {
@@ -1375,7 +1377,7 @@ fn parse_condition(
     after_kw: usize,
     diagnostics: &mut Vec<ParseDiagnostic>,
 ) -> usize {
-    let cond_start = ctx.skip_ws(after_kw);
+    let cond_start = ctx.skip_ws_and_block_comments(after_kw);
     push_range(events, after_kw, cond_start);
     match parse_expr(ctx.tokens(), cond_start, 0, diagnostics) {
         Some(cond) => {
@@ -1414,7 +1416,7 @@ fn parse_signature(
     after_kw: usize,
     diagnostics: &mut Vec<ParseDiagnostic>,
 ) -> usize {
-    let sig_start = ctx.skip_ws(after_kw);
+    let sig_start = ctx.skip_ws_and_block_comments(after_kw);
     push_range(events, after_kw, sig_start);
 
     if header_ends(ctx, sig_start) {
@@ -1452,7 +1454,7 @@ fn parse_header(
     run_expr: bool,
     diagnostics: &mut Vec<ParseDiagnostic>,
 ) -> usize {
-    let header_start = ctx.skip_ws(after_kw);
+    let header_start = ctx.skip_ws_and_block_comments(after_kw);
     push_range(events, after_kw, header_start);
 
     if header_ends(ctx, header_start) {
@@ -1489,9 +1491,9 @@ fn parse_header(
             events.extend(interp.events);
             i = interp.end;
         }
-        // A `,` (possibly preceded by horizontal whitespace) separates the next
-        // binding. Absent a comma, the binding list ends.
-        let sep = ctx.skip_ws(i);
+        // A `,` (possibly preceded by horizontal whitespace or a block comment)
+        // separates the next binding. Absent a comma, the binding list ends.
+        let sep = ctx.skip_ws_and_block_comments(i);
         if ctx.token(sep).map(|t| t.kind) != Some(TokKind::Comma) {
             break;
         }
@@ -1521,7 +1523,8 @@ fn is_close_delimiter_tok(kind: TokKind) -> bool {
 /// comment (which runs to the end of the line, so the header is empty either
 /// way — and stopping here keeps `let # c` from opening a zero-width
 /// `LET_BINDINGS` that `let` alone would not; a `#= … =#` block comment can be
-/// followed by a real binding, so it is not a terminator), a block terminator
+/// followed by a real binding, so it is not a terminator — the header parse
+/// crosses it as trivia via `skip_ws_and_block_comments`), a block terminator
 /// keyword (so one-liners like
 /// `struct Foo end` stop correctly), a closing bracket (so a header nested in
 /// brackets, e.g. a quoted `:(using Flux)`, lets the enclosing bracket close

--- a/tests/fixtures/oracle/keyword_header_block_comment/expected.sexpr
+++ b/tests/fixtures/oracle/keyword_header_block_comment/expected.sexpr
@@ -1,0 +1,1 @@
+(toplevel (let (block (= x 1) (= y 2)) (block (call-i x + y))) (while cond (block (call step!))) (if cond (block a) (elseif b (block c))) (for (= i (call-i 1 : 3)) (block a)) (struct Foo (block)) (function (call f) (block)) (macro (call m) (block)) (module M (block)) (do (call f) (tuple x y) (block x)) (try (block a) (catch e (block b))) (const (= k 1)))

--- a/tests/fixtures/oracle/keyword_header_block_comment/input.jl
+++ b/tests/fixtures/oracle/keyword_header_block_comment/input.jl
@@ -1,0 +1,41 @@
+let #= c =# x = 1, #= d =# y = 2
+    x + y
+end
+
+while #= c =# cond
+    step!()
+end
+
+if #= c =# cond
+    a
+elseif #= d =# b
+    c
+end
+
+for #= c =# i in 1:3
+    a
+end
+
+struct #= c =# Foo
+end
+
+function #= c =# f()
+end
+
+macro #= c =# m()
+end
+
+module #= c =# M
+end
+
+f() do #= c =# x, y
+    x
+end
+
+try
+    a
+catch #= c =# e
+    b
+end
+
+const #= c =# k = 1

--- a/tests/fixtures/parser/keyword_header_block_comment/input.jl
+++ b/tests/fixtures/parser/keyword_header_block_comment/input.jl
@@ -1,0 +1,41 @@
+let #= c =# x = 1, #= d =# y = 2
+    x + y
+end
+
+while #= c =# cond
+    step!()
+end
+
+if #= c =# cond
+    a
+elseif #= d =# b
+    c
+end
+
+for #= c =# i in 1:3
+    a
+end
+
+struct #= c =# Foo
+end
+
+function #= c =# f()
+end
+
+macro #= c =# m()
+end
+
+module #= c =# M
+end
+
+f() do #= c =# x, y
+    x
+end
+
+try
+    a
+catch #= c =# e
+    b
+end
+
+const #= c =# k = 1

--- a/tests/oracle/allowlist.txt
+++ b/tests/oracle/allowlist.txt
@@ -104,6 +104,7 @@ interpolation_names
 invalid_doubled_operators
 juxtaposition
 keyword_args
+keyword_header_block_comment
 keyword_name_error
 keyword_statements
 left_arrow_operator

--- a/tests/snapshots/parser_snapshots__keyword_header_block_comment.snap
+++ b/tests/snapshots/parser_snapshots__keyword_header_block_comment.snap
@@ -1,0 +1,250 @@
+---
+source: tests/parser_snapshots.rs
+expression: rendered
+---
+ROOT@0..349
+  LET_EXPR@0..46
+    LET_KW@0..3 "let"
+    WHITESPACE@3..4 " "
+    BLOCK_COMMENT@4..11 "#= c =#"
+    WHITESPACE@11..12 " "
+    LET_BINDINGS@12..32
+      ASSIGNMENT_EXPR@12..17
+        NAME@12..13
+          IDENT@12..13 "x"
+        WHITESPACE@13..14 " "
+        EQ@14..15 "="
+        WHITESPACE@15..16 " "
+        LITERAL@16..17
+          INTEGER@16..17 "1"
+      COMMA@17..18 ","
+      WHITESPACE@18..19 " "
+      BLOCK_COMMENT@19..26 "#= d =#"
+      WHITESPACE@26..27 " "
+      ASSIGNMENT_EXPR@27..32
+        NAME@27..28
+          IDENT@27..28 "y"
+        WHITESPACE@28..29 " "
+        EQ@29..30 "="
+        WHITESPACE@30..31 " "
+        LITERAL@31..32
+          INTEGER@31..32 "2"
+    BLOCK@32..43
+      NEWLINE@32..33 "\n"
+      WHITESPACE@33..37 "    "
+      BINARY_EXPR@37..42
+        NAME@37..38
+          IDENT@37..38 "x"
+        WHITESPACE@38..39 " "
+        PLUS@39..40 "+"
+        WHITESPACE@40..41 " "
+        NAME@41..42
+          IDENT@41..42 "y"
+      NEWLINE@42..43 "\n"
+    END_KW@43..46 "end"
+  NEWLINE@46..47 "\n"
+  NEWLINE@47..48 "\n"
+  WHILE_EXPR@48..82
+    WHILE_KW@48..53 "while"
+    WHITESPACE@53..54 " "
+    BLOCK_COMMENT@54..61 "#= c =#"
+    WHITESPACE@61..62 " "
+    CONDITION@62..66
+      NAME@62..66
+        IDENT@62..66 "cond"
+    BLOCK@66..79
+      NEWLINE@66..67 "\n"
+      WHITESPACE@67..71 "    "
+      CALL_EXPR@71..78
+        NAME@71..76
+          IDENT@71..76 "step!"
+        ARG_LIST@76..78
+          LPAREN@76..77 "("
+          RPAREN@77..78 ")"
+      NEWLINE@78..79 "\n"
+    END_KW@79..82 "end"
+  NEWLINE@82..83 "\n"
+  NEWLINE@83..84 "\n"
+  IF_EXPR@84..132
+    IF_KW@84..86 "if"
+    WHITESPACE@86..87 " "
+    BLOCK_COMMENT@87..94 "#= c =#"
+    WHITESPACE@94..95 " "
+    CONDITION@95..99
+      NAME@95..99
+        IDENT@95..99 "cond"
+    BLOCK@99..106
+      NEWLINE@99..100 "\n"
+      WHITESPACE@100..104 "    "
+      NAME@104..105
+        IDENT@104..105 "a"
+      NEWLINE@105..106 "\n"
+    ELSEIF_CLAUSE@106..129
+      ELSEIF_KW@106..112 "elseif"
+      WHITESPACE@112..113 " "
+      BLOCK_COMMENT@113..120 "#= d =#"
+      WHITESPACE@120..121 " "
+      CONDITION@121..122
+        NAME@121..122
+          IDENT@121..122 "b"
+      BLOCK@122..129
+        NEWLINE@122..123 "\n"
+        WHITESPACE@123..127 "    "
+        NAME@127..128
+          IDENT@127..128 "c"
+        NEWLINE@128..129 "\n"
+    END_KW@129..132 "end"
+  NEWLINE@132..133 "\n"
+  NEWLINE@133..134 "\n"
+  FOR_EXPR@134..164
+    FOR_KW@134..137 "for"
+    WHITESPACE@137..138 " "
+    BLOCK_COMMENT@138..145 "#= c =#"
+    WHITESPACE@145..146 " "
+    FOR_BINDING@146..154
+      NAME@146..147
+        IDENT@146..147 "i"
+      WHITESPACE@147..148 " "
+      IDENT@148..150 "in"
+      WHITESPACE@150..151 " "
+      BINARY_EXPR@151..154
+        LITERAL@151..152
+          INTEGER@151..152 "1"
+        COLON@152..153 ":"
+        LITERAL@153..154
+          INTEGER@153..154 "3"
+    BLOCK@154..161
+      NEWLINE@154..155 "\n"
+      WHITESPACE@155..159 "    "
+      NAME@159..160
+        IDENT@159..160 "a"
+      NEWLINE@160..161 "\n"
+    END_KW@161..164 "end"
+  NEWLINE@164..165 "\n"
+  NEWLINE@165..166 "\n"
+  STRUCT_DEF@166..188
+    STRUCT_KW@166..172 "struct"
+    WHITESPACE@172..173 " "
+    BLOCK_COMMENT@173..180 "#= c =#"
+    WHITESPACE@180..181 " "
+    SIGNATURE@181..184
+      NAME@181..184
+        IDENT@181..184 "Foo"
+    BLOCK@184..185
+      NEWLINE@184..185 "\n"
+    END_KW@185..188 "end"
+  NEWLINE@188..189 "\n"
+  NEWLINE@189..190 "\n"
+  FUNCTION_DEF@190..214
+    FUNCTION_KW@190..198 "function"
+    WHITESPACE@198..199 " "
+    BLOCK_COMMENT@199..206 "#= c =#"
+    WHITESPACE@206..207 " "
+    SIGNATURE@207..210
+      CALL_EXPR@207..210
+        NAME@207..208
+          IDENT@207..208 "f"
+        ARG_LIST@208..210
+          LPAREN@208..209 "("
+          RPAREN@209..210 ")"
+    BLOCK@210..211
+      NEWLINE@210..211 "\n"
+    END_KW@211..214 "end"
+  NEWLINE@214..215 "\n"
+  NEWLINE@215..216 "\n"
+  MACRO_DEF@216..237
+    MACRO_KW@216..221 "macro"
+    WHITESPACE@221..222 " "
+    BLOCK_COMMENT@222..229 "#= c =#"
+    WHITESPACE@229..230 " "
+    SIGNATURE@230..233
+      CALL_EXPR@230..233
+        NAME@230..231
+          IDENT@230..231 "m"
+        ARG_LIST@231..233
+          LPAREN@231..232 "("
+          RPAREN@232..233 ")"
+    BLOCK@233..234
+      NEWLINE@233..234 "\n"
+    END_KW@234..237 "end"
+  NEWLINE@237..238 "\n"
+  NEWLINE@238..239 "\n"
+  MODULE_DEF@239..259
+    MODULE_KW@239..245 "module"
+    WHITESPACE@245..246 " "
+    BLOCK_COMMENT@246..253 "#= c =#"
+    WHITESPACE@253..254 " "
+    SIGNATURE@254..255
+      NAME@254..255
+        IDENT@254..255 "M"
+    BLOCK@255..256
+      NEWLINE@255..256 "\n"
+    END_KW@256..259 "end"
+  NEWLINE@259..260 "\n"
+  NEWLINE@260..261 "\n"
+  DO_EXPR@261..290
+    CALL_EXPR@261..264
+      NAME@261..262
+        IDENT@261..262 "f"
+      ARG_LIST@262..264
+        LPAREN@262..263 "("
+        RPAREN@263..264 ")"
+    WHITESPACE@264..265 " "
+    DO_KW@265..267 "do"
+    WHITESPACE@267..268 " "
+    BLOCK_COMMENT@268..275 "#= c =#"
+    WHITESPACE@275..276 " "
+    DO_PARAMS@276..280
+      NAME@276..277
+        IDENT@276..277 "x"
+      COMMA@277..278 ","
+      WHITESPACE@278..279 " "
+      NAME@279..280
+        IDENT@279..280 "y"
+    BLOCK@280..287
+      NEWLINE@280..281 "\n"
+      WHITESPACE@281..285 "    "
+      NAME@285..286
+        IDENT@285..286 "x"
+      NEWLINE@286..287 "\n"
+    END_KW@287..290 "end"
+  NEWLINE@290..291 "\n"
+  NEWLINE@291..292 "\n"
+  TRY_EXPR@292..327
+    TRY_KW@292..295 "try"
+    BLOCK@295..302
+      NEWLINE@295..296 "\n"
+      WHITESPACE@296..300 "    "
+      NAME@300..301
+        IDENT@300..301 "a"
+      NEWLINE@301..302 "\n"
+    CATCH_CLAUSE@302..324
+      CATCH_KW@302..307 "catch"
+      WHITESPACE@307..308 " "
+      BLOCK_COMMENT@308..315 "#= c =#"
+      WHITESPACE@315..316 " "
+      NAME@316..317
+        IDENT@316..317 "e"
+      BLOCK@317..324
+        NEWLINE@317..318 "\n"
+        WHITESPACE@318..322 "    "
+        NAME@322..323
+          IDENT@322..323 "b"
+        NEWLINE@323..324 "\n"
+    END_KW@324..327 "end"
+  NEWLINE@327..328 "\n"
+  NEWLINE@328..329 "\n"
+  CONST_STMT@329..348
+    CONST_KW@329..334 "const"
+    WHITESPACE@334..335 " "
+    BLOCK_COMMENT@335..342 "#= c =#"
+    WHITESPACE@342..343 " "
+    ASSIGNMENT_EXPR@343..348
+      NAME@343..344
+        IDENT@343..344 "k"
+      WHITESPACE@344..345 " "
+      EQ@345..346 "="
+      WHITESPACE@346..347 " "
+      LITERAL@347..348
+        INTEGER@347..348 "1"
+  NEWLINE@348..349 "\n"


### PR DESCRIPTION
`skip_ws` does not cross comments, so every "the header starts after this
keyword" site landed on a `#= … =#` token instead of the header. `header_ends`
deliberately does not list `BlockComment` (a real header can follow one, unlike
a line comment), so the header opened anyway, `parse_expr` returned `None` at
the comment, and the header expression fell through into the body block.

`let #= c =# x = 1` moved the binding out of `LET_BINDINGS` silently — a
scoping change — and `if`/`elseif`/`while` also raised a spurious `expected a
condition`, failing `debug format` with `format-error`. `struct`, `function`,
`macro`, `module`, `do`, `catch`, `return` and `const` were affected the same
way.

Add `skip_ws_and_block_comments` and use it at every header-start site, plus
the two comma lookaheads that continue a header list. A block comment's own
newlines ride along: Julia does not end the header at a multi-line `#= … =#`
either. A line comment stays a terminator.

`parse_function_like` already crossed newlines, so it moves to the full
`skip_trivia` — its signature is never empty, so no comment there can end it.
That also fixes `function # c\n f() end`.

Closes #42