### PR TITLE
chore(release): v0.10.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "26e061c0713f76e8e65394e234d65bde0ec946a3",
+  "baseline-sha": "a9b62c18c87106f1ea6fdf0ac4f0dda9bb3cd093",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.9.0",
-      "tag": "v0.9.0"
+      "version": "0.10.0",
+      "tag": "v0.10.0"
     },
     {
       "path": "editors/code",
-      "version": "0.9.0",
-      "tag": "fatou-code-v0.9.0"
+      "version": "0.10.0",
+      "tag": "fatou-code-v0.10.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.9.0",
-      "tag": "v0.9.0"
+      "version": "0.10.0",
+      "tag": "v0.10.0"
     },
     {
       "path": "editors/code",
-      "version": "0.9.0",
-      "tag": "fatou-code-v0.9.0"
+      "version": "0.10.0",
+      "tag": "fatou-code-v0.10.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/fatou/compare/v0.9.0...v0.10.0) (2026-08-03)
+
+### Features
+- **formatter:** break args before a short where bound ([`a9b62c1`](https://github.com/jolars/fatou/commit/a9b62c18c87106f1ea6fdf0ac4f0dda9bb3cd093))
+- **formatter:** glue sole brace/bracket macro arg ([`dcf2d87`](https://github.com/jolars/fatou/commit/dcf2d874c9134217ec063828616c44109d2cc06e))
+- **linter:** add `type-piracy` rule ([`7c5d935`](https://github.com/jolars/fatou/commit/7c5d935182b2ca39aac0c184798a93a12f170c95))
+- **parser:** add debug-only event balance check ([`cca89c2`](https://github.com/jolars/fatou/commit/cca89c2b02e7b3a0a9deeceb11de65304ff40a83))
+- **build:** add installation scripts ([`16b941a`](https://github.com/jolars/fatou/commit/16b941ae00b38443c55c406e571d017459930485))
+- **build:** add deb and rpm packages ([`fd823b5`](https://github.com/jolars/fatou/commit/fd823b5f33933bd6b387a31d68998d0319b477ef))
+- **resolve:** resolve sibling `using`/`import` cross-file ([`fd6d0cb`](https://github.com/jolars/fatou/commit/fd6d0cbda681161ff9defcf811f4afef59703440))
+
+### Bug Fixes
+- **formatter:** drop magic comma after space-form macrocall ([`6068f60`](https://github.com/jolars/fatou/commit/6068f600c12762b0d0fb96904a0210edc55d3e94)), closes [#56](https://github.com/jolars/fatou/issues/56)
+- **incremental:** pin workspace seed order by path ([`3a6ad4d`](https://github.com/jolars/fatou/commit/3a6ad4dedc82d82a23515c3ad62423520f4c4687))
+- **resolve:** count quoted and operator import uses ([`239d05b`](https://github.com/jolars/fatou/commit/239d05b49c533139aff3b7bf6414affe55f50c8f))
+- **parser:** fold macro trailing comma into tuple arg ([`e3b0254`](https://github.com/jolars/fatou/commit/e3b0254424cb7e91a09603f9a80575337703449f))
+- **resolve:** resolve a module's own name in workspace tier ([`f2b7fa5`](https://github.com/jolars/fatou/commit/f2b7fa5fec9534b7f76571161fda68cf62fa3f66))
+- **index:** export each module's own name from harvest ([`0d75046`](https://github.com/jolars/fatou/commit/0d750466dd391bcd15283151e10f7a0882db0541))
+- **semantic:** count interpolation in prefixed string macros ([`366b5c1`](https://github.com/jolars/fatou/commit/366b5c166b19ea9a16d6f8fca902e67f0134aa08))
+- **semantic:** treat infix operator defs as method extensions ([`078294e`](https://github.com/jolars/fatou/commit/078294e0d56e0ef341b77f2d3fa256277a8ef8cf)), closes [#53](https://github.com/jolars/fatou/issues/53)
+- **lint:** exempt attribute-DSL macro blocks from unused-binding ([`30370d7`](https://github.com/jolars/fatou/commit/30370d7452221ff117120a31e3a7ad85e636fb7c))
+- **semantic:** bind typed defaulted params instead of flagging them ([`b37811a`](https://github.com/jolars/fatou/commit/b37811adf47971ea65043c0b43cd4c8f418a76a8))
+- **semantic:** count string and command macro use as import use ([`70be463`](https://github.com/jolars/fatou/commit/70be4634ae457df943069451d49f9dd5416b4197))
+- **lint:** exempt macro-call blocks from redefined-constant ([`df4abae`](https://github.com/jolars/fatou/commit/df4abaeacfc4618083fda3b78a43df99944947b0))
+
 ## [0.9.0](https://github.com/jolars/fatou/compare/v0.8.0...v0.9.0) (2026-08-01)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -427,7 +427,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -563,9 +563,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -673,9 +673,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -970,9 +970,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14fdadbf856222e731756d7fdbdf193a7abf8fdab009bb45f48671a42719a84"
+checksum = "cf0e374215cd2db2b5c75d7b3a99cb0cc052c0595335dfdefc03d4eb08f4aa81"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -996,19 +996,19 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d7dc08ba69b9aedfa61dfc4d65548ae42c0d8b90bbd62cd121776920841bcf"
+checksum = "85f4b7d4405540bbd6d4ffa52d4322d983f3781954d3073067ac1bdb028459b3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5c48c5a4a53a6e2be9762f56566f1325d4394c011c00b3ea86ba2d13411e71"
+checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/fatou/compare/fatou-code-v0.9.0...fatou-code-v0.10.0) (2026-08-03)
+
+### Dependencies
+- updated fatou to v0.10.0
+
 ## [0.9.0](https://github.com/jolars/fatou/compare/fatou-code-v0.8.0...fatou-code-v0.9.0) (2026-08-01)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.9.0",
-    "@fatou-cli/linux-arm64-gnu": "0.9.0",
-    "@fatou-cli/linux-x64-musl": "0.9.0",
-    "@fatou-cli/linux-arm64-musl": "0.9.0",
-    "@fatou-cli/darwin-x64": "0.9.0",
-    "@fatou-cli/darwin-arm64": "0.9.0",
-    "@fatou-cli/win32-x64": "0.9.0",
-    "@fatou-cli/win32-arm64": "0.9.0"
+    "@fatou-cli/linux-x64-gnu": "0.10.0",
+    "@fatou-cli/linux-arm64-gnu": "0.10.0",
+    "@fatou-cli/linux-x64-musl": "0.10.0",
+    "@fatou-cli/linux-arm64-musl": "0.10.0",
+    "@fatou-cli/darwin-x64": "0.10.0",
+    "@fatou-cli/darwin-arm64": "0.10.0",
+    "@fatou-cli/win32-x64": "0.10.0",
+    "@fatou-cli/win32-arm64": "0.10.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.10.0](https://github.com/jolars/fatou/compare/v0.9.0...v0.10.0) (2026-08-03)

### Features
- **formatter:** break args before a short where bound ([`a9b62c1`](https://github.com/jolars/fatou/commit/a9b62c18c87106f1ea6fdf0ac4f0dda9bb3cd093))
- **formatter:** glue sole brace/bracket macro arg ([`dcf2d87`](https://github.com/jolars/fatou/commit/dcf2d874c9134217ec063828616c44109d2cc06e))
- **linter:** add `type-piracy` rule ([`7c5d935`](https://github.com/jolars/fatou/commit/7c5d935182b2ca39aac0c184798a93a12f170c95))
- **parser:** add debug-only event balance check ([`cca89c2`](https://github.com/jolars/fatou/commit/cca89c2b02e7b3a0a9deeceb11de65304ff40a83))
- **build:** add installation scripts ([`16b941a`](https://github.com/jolars/fatou/commit/16b941ae00b38443c55c406e571d017459930485))
- **build:** add deb and rpm packages ([`fd823b5`](https://github.com/jolars/fatou/commit/fd823b5f33933bd6b387a31d68998d0319b477ef))
- **resolve:** resolve sibling `using`/`import` cross-file ([`fd6d0cb`](https://github.com/jolars/fatou/commit/fd6d0cbda681161ff9defcf811f4afef59703440))

### Bug Fixes
- **formatter:** drop magic comma after space-form macrocall ([`6068f60`](https://github.com/jolars/fatou/commit/6068f600c12762b0d0fb96904a0210edc55d3e94)), closes [#56](https://github.com/jolars/fatou/issues/56)
- **incremental:** pin workspace seed order by path ([`3a6ad4d`](https://github.com/jolars/fatou/commit/3a6ad4dedc82d82a23515c3ad62423520f4c4687))
- **resolve:** count quoted and operator import uses ([`239d05b`](https://github.com/jolars/fatou/commit/239d05b49c533139aff3b7bf6414affe55f50c8f))
- **parser:** fold macro trailing comma into tuple arg ([`e3b0254`](https://github.com/jolars/fatou/commit/e3b0254424cb7e91a09603f9a80575337703449f))
- **resolve:** resolve a module's own name in workspace tier ([`f2b7fa5`](https://github.com/jolars/fatou/commit/f2b7fa5fec9534b7f76571161fda68cf62fa3f66))
- **index:** export each module's own name from harvest ([`0d75046`](https://github.com/jolars/fatou/commit/0d750466dd391bcd15283151e10f7a0882db0541))
- **semantic:** count interpolation in prefixed string macros ([`366b5c1`](https://github.com/jolars/fatou/commit/366b5c166b19ea9a16d6f8fca902e67f0134aa08))
- **semantic:** treat infix operator defs as method extensions ([`078294e`](https://github.com/jolars/fatou/commit/078294e0d56e0ef341b77f2d3fa256277a8ef8cf)), closes [#53](https://github.com/jolars/fatou/issues/53)
- **lint:** exempt attribute-DSL macro blocks from unused-binding ([`30370d7`](https://github.com/jolars/fatou/commit/30370d7452221ff117120a31e3a7ad85e636fb7c))
- **semantic:** bind typed defaulted params instead of flagging them ([`b37811a`](https://github.com/jolars/fatou/commit/b37811adf47971ea65043c0b43cd4c8f418a76a8))
- **semantic:** count string and command macro use as import use ([`70be463`](https://github.com/jolars/fatou/commit/70be4634ae457df943069451d49f9dd5416b4197))
- **lint:** exempt macro-call blocks from redefined-constant ([`df4abae`](https://github.com/jolars/fatou/commit/df4abaeacfc4618083fda3b78a43df99944947b0))

## [editors/code: 0.10.0](https://github.com/jolars/fatou/compare/fatou-code-v0.9.0...fatou-code-v0.10.0) (2026-08-03)

### Dependencies
- updated fatou to v0.10.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).