### PR TITLE
chore(release): v0.11.0 (+2 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,38 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "a9b62c18c87106f1ea6fdf0ac4f0dda9bb3cd093",
+  "baseline-sha": "501624d153495e2de5f8a7e5c8bdbc14a5627c4b",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
+    },
+    {
+      "path": "crates/fatou-formatter",
+      "version": "0.2.0",
+      "tag": "fatou-formatter-v0.2.0"
     },
     {
       "path": "editors/code",
-      "version": "0.10.0",
-      "tag": "fatou-code-v0.10.0"
+      "version": "0.11.0",
+      "tag": "fatou-code-v0.11.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
+    },
+    {
+      "path": "crates/fatou-formatter",
+      "version": "0.2.0",
+      "tag": "fatou-formatter-v0.2.0"
     },
     {
       "path": "editors/code",
-      "version": "0.10.0",
-      "tag": "fatou-code-v0.10.0"
+      "version": "0.11.0",
+      "tag": "fatou-code-v0.11.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/fatou/compare/v0.10.0...v0.11.0) (2026-08-07)
+
+### Breaking changes
+- **config:** stop discovery at the repository root ([`19b5289`](https://github.com/jolars/fatou/commit/19b5289c878d5179130d8fdb93d4846c6b840ffa))
+
+### Features
+- **lsp:** complete LaTeX and emoji sequences ([`501624d`](https://github.com/jolars/fatou/commit/501624d153495e2de5f8a7e5c8bdbc14a5627c4b)), closes [#70](https://github.com/jolars/fatou/issues/70)
+- **code:** add feature toggles for the extension ([`c63f731`](https://github.com/jolars/fatou/commit/c63f7312edf0105d38f376d0160d64d4967ad503))
+- **bench:** add DataFrames corpus and two single-file targets ([`74eb785`](https://github.com/jolars/fatou/commit/74eb7858743ad8706b69b9ec97e6905467b7ac6c))
+- **lint:** add `duplicate-include` rule ([`f95e44c`](https://github.com/jolars/fatou/commit/f95e44c9645e195c292717adc226ff28880ed4b4))
+- **lint:** add unsafe fix for `index-from-length` ([`2c126ea`](https://github.com/jolars/fatou/commit/2c126ea98ef7261bade3693d4b9584693772132c))
+- **formatter:** add `serde` and `schema` features ([`010f07c`](https://github.com/jolars/fatou/commit/010f07cde08ab22b02932512fecb74188e994182))
+- **cli:** add global `--quiet` to trim `format --check` ([`06ffd50`](https://github.com/jolars/fatou/commit/06ffd503ce26c92ed74b551ab037281636fe6507))
+- **linter:** add per-rule config and `discouraged-function` ([`c46a9c8`](https://github.com/jolars/fatou/commit/c46a9c8eecd5ebbdca1f14ca8c02569b07519b47))
+- **semantic:** add per-region control-flow graph ([`75c14ac`](https://github.com/jolars/fatou/commit/75c14aca5022fb0e5b2320fd0f0fb8ee1c1d5835))
+- **linter:** add shared call-shape matcher module ([`cb66218`](https://github.com/jolars/fatou/commit/cb66218d7e7aeb6aa1bd613f7885d560dd7f616e))
+- **linter:** add base-resolution helpers to RuleContext ([`c4b92fd`](https://github.com/jolars/fatou/commit/c4b92fd9f1b73179e7df6ea22d9cb2016f640d21))
+- **linter:** add missing-comparison rule ([`e69da85`](https://github.com/jolars/fatou/commit/e69da85490c008ab605777c1796d7728c14cce1d))
+- **config:** stop discovery at the repository root ([`19b5289`](https://github.com/jolars/fatou/commit/19b5289c878d5179130d8fdb93d4846c6b840ffa))
+- **config:** support a global user config ([`223c96f`](https://github.com/jolars/fatou/commit/223c96fa19a8d0b64c5906609c4e83ef7f2c12f8)), closes [#69](https://github.com/jolars/fatou/issues/69)
+- **formatter:** hug only a sole trailing item ([`bc23056`](https://github.com/jolars/fatou/commit/bc23056ea6c004e7a6d0e26d1f545f0f8730078d))
+- **parser:** let string-content reparse span newlines ([`30e983d`](https://github.com/jolars/fatou/commit/30e983d0e17b5163c4fbd5bac2141a904b600656))
+- **parser:** reparse string content at the token tier ([`70e6c9f`](https://github.com/jolars/fatou/commit/70e6c9feda5e9a68a740b9cb95461ab41c9eef46))
+- **parser:** add precise LSP edit reparse tier ([`f105b39`](https://github.com/jolars/fatou/commit/f105b3914570bd141e07dfbd2d16c21362877fbd))
+- **parser:** add top-level statement reparse tier ([`52dd6d9`](https://github.com/jolars/fatou/commit/52dd6d97998e66ebe8541641fe530aec6f128d76))
+- **parser:** add token-tier reparse splice ([`58365d6`](https://github.com/jolars/fatou/commit/58365d6d43f43e202f99689523541992841d7179))
+- **parser:** reparse infra and salsa side-channel ([`6ea9a6d`](https://github.com/jolars/fatou/commit/6ea9a6dab640dbb647a345a9bf005ef34438d350))
+- **linter:** add index-from-length rule ([`812413c`](https://github.com/jolars/fatou/commit/812413c0de5a1629f719fd32f1a259251ba9fcfe))
+- **formatter:** where-priority for return-type sigs ([`f4b423c`](https://github.com/jolars/fatou/commit/f4b423c970dff916b14ad16c5aa8f96376bb8f74))
+
+### Bug Fixes
+- **lint:** count a generator as one positional argument ([`2d9ec6b`](https://github.com/jolars/fatou/commit/2d9ec6b3eaf40a46d1fa417e6ec43b4e171539a0))
+- **bench:** report files JuliaFormatter cannot rewrite ([`70f70b9`](https://github.com/jolars/fatou/commit/70f70b9b00580409298df8d02fa178dd974fa026))
+- **docs:** exclude `doc-utils` from the cargo workspace ([`150917f`](https://github.com/jolars/fatou/commit/150917f35b07199c50a364c46648ea9b9e703ffc))
+- **config:** honor `$HOME` and `%APPDATA%` on Windows ([`b376c0c`](https://github.com/jolars/fatou/commit/b376c0c3aa8ec65fe08a94fbb09a7ddc5d391a11))
+- **parser:** close three gaps in the reparse guards ([`50eb35a`](https://github.com/jolars/fatou/commit/50eb35a0e775471ca23da2223a444bf404187489))
+- **lsp:** match only the minted synthetic path shape ([`6d615ed`](https://github.com/jolars/fatou/commit/6d615ede10760339867037b38626a3327f5bb82e))
+- **parser:** bound reparse cost and cache growth ([`fa1cae0`](https://github.com/jolars/fatou/commit/fa1cae0aee5219d1fe4a02b2c9c69d97d3e86e52))
+- **parser:** guard neighbor coupling across a trivia region ([`3bbc075`](https://github.com/jolars/fatou/commit/3bbc07548e80cf4709491680185f7068d7432767))
+- **lsp:** give each non-file URI its own tracked path ([`81e0fcc`](https://github.com/jolars/fatou/commit/81e0fcc30fcfb014cc1154b8a6db8d3b99868b5b))
+- **lsp:** drop queued analyses on document close ([`0f207d5`](https://github.com/jolars/fatou/commit/0f207d51211945047873ae1480a15b99149dc7de))
+- **lexer:** keep multi-byte chars whole in string escapes ([`065a69a`](https://github.com/jolars/fatou/commit/065a69a87d067c95b3c6f9eed2a944a4ec92de99))
+- **installer:** detect musl/glibc in oneline installer ([`6d460fd`](https://github.com/jolars/fatou/commit/6d460fd8f33163f9fb784cab9e6b23b925b1c80f))
+- **npm:** fall back to musl when glibc build fails ([`4897836`](https://github.com/jolars/fatou/commit/48978367e8dcda0895c42e60c6d39c18a744c115))
+
+### Performance Improvements
+- **semantic:** index unreachable statements by range ([`0662c8d`](https://github.com/jolars/fatou/commit/0662c8d3a0e5e504c45109ae21c9cade643cb85d))
+
+### Dependencies
+- updated crates/fatou-formatter to v0.2.0
+
 ## [0.10.0](https://github.com/jolars/fatou/compare/v0.9.0...v0.10.0) (2026-08-03)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -264,9 +264,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+checksum = "c630ddc90572b3d9abd3f887f0007b4e048faf5c5a59ae607f8ac1c5e3790873"
 dependencies = [
  "clap",
  "roff",
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -555,7 +555,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
- "similar 3.1.1",
+ "similar 3.1.2",
  "smol_str",
  "tempfile",
  "toml",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -707,9 +707,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -745,12 +745,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -1093,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1344,9 +1341,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
 ]
@@ -1641,18 +1638,18 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"
@@ -49,7 +49,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5"
 dirs = "6"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.1.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.2.0" }
 fatou-parser = { path = "crates/fatou-parser", version = "0.1.0" }
 globset = "0.4.18"
 ignore = "0.4.26"

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.1.0...fatou-formatter-v0.2.0) (2026-08-07)
+
+### Features
+- **formatter:** add `serde` and `schema` features ([`010f07c`](https://github.com/jolars/fatou/commit/010f07cde08ab22b02932512fecb74188e994182))

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for the Julia language"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/fatou/compare/fatou-code-v0.10.0...fatou-code-v0.11.0) (2026-08-07)
+
+### Features
+- **code:** add feature toggles for the extension ([`c63f731`](https://github.com/jolars/fatou/commit/c63f7312edf0105d38f376d0160d64d4967ad503))
+
+### Dependencies
+- updated fatou to v0.11.0
+
 ## [0.10.0](https://github.com/jolars/fatou/compare/fatou-code-v0.9.0...fatou-code-v0.10.0) (2026-08-03)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.10.0",
-    "@fatou-cli/linux-arm64-gnu": "0.10.0",
-    "@fatou-cli/linux-x64-musl": "0.10.0",
-    "@fatou-cli/linux-arm64-musl": "0.10.0",
-    "@fatou-cli/darwin-x64": "0.10.0",
-    "@fatou-cli/darwin-arm64": "0.10.0",
-    "@fatou-cli/win32-x64": "0.10.0",
-    "@fatou-cli/win32-arm64": "0.10.0"
+    "@fatou-cli/linux-x64-gnu": "0.11.0",
+    "@fatou-cli/linux-arm64-gnu": "0.11.0",
+    "@fatou-cli/linux-x64-musl": "0.11.0",
+    "@fatou-cli/linux-arm64-musl": "0.11.0",
+    "@fatou-cli/darwin-x64": "0.11.0",
+    "@fatou-cli/darwin-arm64": "0.11.0",
+    "@fatou-cli/win32-x64": "0.11.0",
+    "@fatou-cli/win32-arm64": "0.11.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.11.0](https://github.com/jolars/fatou/compare/v0.10.0...v0.11.0) (2026-08-07)

### Breaking changes
- **config:** stop discovery at the repository root ([`19b5289`](https://github.com/jolars/fatou/commit/19b5289c878d5179130d8fdb93d4846c6b840ffa))

### Features
- **lsp:** complete LaTeX and emoji sequences ([`501624d`](https://github.com/jolars/fatou/commit/501624d153495e2de5f8a7e5c8bdbc14a5627c4b)), closes [#70](https://github.com/jolars/fatou/issues/70)
- **code:** add feature toggles for the extension ([`c63f731`](https://github.com/jolars/fatou/commit/c63f7312edf0105d38f376d0160d64d4967ad503))
- **bench:** add DataFrames corpus and two single-file targets ([`74eb785`](https://github.com/jolars/fatou/commit/74eb7858743ad8706b69b9ec97e6905467b7ac6c))
- **lint:** add `duplicate-include` rule ([`f95e44c`](https://github.com/jolars/fatou/commit/f95e44c9645e195c292717adc226ff28880ed4b4))
- **lint:** add unsafe fix for `index-from-length` ([`2c126ea`](https://github.com/jolars/fatou/commit/2c126ea98ef7261bade3693d4b9584693772132c))
- **formatter:** add `serde` and `schema` features ([`010f07c`](https://github.com/jolars/fatou/commit/010f07cde08ab22b02932512fecb74188e994182))
- **cli:** add global `--quiet` to trim `format --check` ([`06ffd50`](https://github.com/jolars/fatou/commit/06ffd503ce26c92ed74b551ab037281636fe6507))
- **linter:** add per-rule config and `discouraged-function` ([`c46a9c8`](https://github.com/jolars/fatou/commit/c46a9c8eecd5ebbdca1f14ca8c02569b07519b47))
- **semantic:** add per-region control-flow graph ([`75c14ac`](https://github.com/jolars/fatou/commit/75c14aca5022fb0e5b2320fd0f0fb8ee1c1d5835))
- **linter:** add shared call-shape matcher module ([`cb66218`](https://github.com/jolars/fatou/commit/cb66218d7e7aeb6aa1bd613f7885d560dd7f616e))
- **linter:** add base-resolution helpers to RuleContext ([`c4b92fd`](https://github.com/jolars/fatou/commit/c4b92fd9f1b73179e7df6ea22d9cb2016f640d21))
- **linter:** add missing-comparison rule ([`e69da85`](https://github.com/jolars/fatou/commit/e69da85490c008ab605777c1796d7728c14cce1d))
- **config:** stop discovery at the repository root ([`19b5289`](https://github.com/jolars/fatou/commit/19b5289c878d5179130d8fdb93d4846c6b840ffa))
- **config:** support a global user config ([`223c96f`](https://github.com/jolars/fatou/commit/223c96fa19a8d0b64c5906609c4e83ef7f2c12f8)), closes [#69](https://github.com/jolars/fatou/issues/69)
- **formatter:** hug only a sole trailing item ([`bc23056`](https://github.com/jolars/fatou/commit/bc23056ea6c004e7a6d0e26d1f545f0f8730078d))
- **parser:** let string-content reparse span newlines ([`30e983d`](https://github.com/jolars/fatou/commit/30e983d0e17b5163c4fbd5bac2141a904b600656))
- **parser:** reparse string content at the token tier ([`70e6c9f`](https://github.com/jolars/fatou/commit/70e6c9feda5e9a68a740b9cb95461ab41c9eef46))
- **parser:** add precise LSP edit reparse tier ([`f105b39`](https://github.com/jolars/fatou/commit/f105b3914570bd141e07dfbd2d16c21362877fbd))
- **parser:** add top-level statement reparse tier ([`52dd6d9`](https://github.com/jolars/fatou/commit/52dd6d97998e66ebe8541641fe530aec6f128d76))
- **parser:** add token-tier reparse splice ([`58365d6`](https://github.com/jolars/fatou/commit/58365d6d43f43e202f99689523541992841d7179))
- **parser:** reparse infra and salsa side-channel ([`6ea9a6d`](https://github.com/jolars/fatou/commit/6ea9a6dab640dbb647a345a9bf005ef34438d350))
- **linter:** add index-from-length rule ([`812413c`](https://github.com/jolars/fatou/commit/812413c0de5a1629f719fd32f1a259251ba9fcfe))
- **formatter:** where-priority for return-type sigs ([`f4b423c`](https://github.com/jolars/fatou/commit/f4b423c970dff916b14ad16c5aa8f96376bb8f74))

### Bug Fixes
- **lint:** count a generator as one positional argument ([`2d9ec6b`](https://github.com/jolars/fatou/commit/2d9ec6b3eaf40a46d1fa417e6ec43b4e171539a0))
- **bench:** report files JuliaFormatter cannot rewrite ([`70f70b9`](https://github.com/jolars/fatou/commit/70f70b9b00580409298df8d02fa178dd974fa026))
- **docs:** exclude `doc-utils` from the cargo workspace ([`150917f`](https://github.com/jolars/fatou/commit/150917f35b07199c50a364c46648ea9b9e703ffc))
- **config:** honor `$HOME` and `%APPDATA%` on Windows ([`b376c0c`](https://github.com/jolars/fatou/commit/b376c0c3aa8ec65fe08a94fbb09a7ddc5d391a11))
- **parser:** close three gaps in the reparse guards ([`50eb35a`](https://github.com/jolars/fatou/commit/50eb35a0e775471ca23da2223a444bf404187489))
- **lsp:** match only the minted synthetic path shape ([`6d615ed`](https://github.com/jolars/fatou/commit/6d615ede10760339867037b38626a3327f5bb82e))
- **parser:** bound reparse cost and cache growth ([`fa1cae0`](https://github.com/jolars/fatou/commit/fa1cae0aee5219d1fe4a02b2c9c69d97d3e86e52))
- **parser:** guard neighbor coupling across a trivia region ([`3bbc075`](https://github.com/jolars/fatou/commit/3bbc07548e80cf4709491680185f7068d7432767))
- **lsp:** give each non-file URI its own tracked path ([`81e0fcc`](https://github.com/jolars/fatou/commit/81e0fcc30fcfb014cc1154b8a6db8d3b99868b5b))
- **lsp:** drop queued analyses on document close ([`0f207d5`](https://github.com/jolars/fatou/commit/0f207d51211945047873ae1480a15b99149dc7de))
- **lexer:** keep multi-byte chars whole in string escapes ([`065a69a`](https://github.com/jolars/fatou/commit/065a69a87d067c95b3c6f9eed2a944a4ec92de99))
- **installer:** detect musl/glibc in oneline installer ([`6d460fd`](https://github.com/jolars/fatou/commit/6d460fd8f33163f9fb784cab9e6b23b925b1c80f))
- **npm:** fall back to musl when glibc build fails ([`4897836`](https://github.com/jolars/fatou/commit/48978367e8dcda0895c42e60c6d39c18a744c115))

### Performance Improvements
- **semantic:** index unreachable statements by range ([`0662c8d`](https://github.com/jolars/fatou/commit/0662c8d3a0e5e504c45109ae21c9cade643cb85d))

### Dependencies
- updated crates/fatou-formatter to v0.2.0

## [crates/fatou-formatter: 0.2.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.1.0...fatou-formatter-v0.2.0) (2026-08-07)

### Features
- **formatter:** add `serde` and `schema` features ([`010f07c`](https://github.com/jolars/fatou/commit/010f07cde08ab22b02932512fecb74188e994182))

## [editors/code: 0.11.0](https://github.com/jolars/fatou/compare/fatou-code-v0.10.0...fatou-code-v0.11.0) (2026-08-07)

### Features
- **code:** add feature toggles for the extension ([`c63f731`](https://github.com/jolars/fatou/commit/c63f7312edf0105d38f376d0160d64d4967ad503))

### Dependencies
- updated fatou to v0.11.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).