### PR TITLE
chore(release): v0.11.1 (+2 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,38 +1,38 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "501624d153495e2de5f8a7e5c8bdbc14a5627c4b",
+  "baseline-sha": "ac48a0090e859f1796d3b1531cbc58130ea24946",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.11.0",
-      "tag": "v0.11.0"
+      "version": "0.11.1",
+      "tag": "v0.11.1"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.2.0",
-      "tag": "fatou-formatter-v0.2.0"
+      "version": "0.2.1",
+      "tag": "fatou-formatter-v0.2.1"
     },
     {
       "path": "editors/code",
-      "version": "0.11.0",
-      "tag": "fatou-code-v0.11.0"
+      "version": "0.11.1",
+      "tag": "fatou-code-v0.11.1"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.11.0",
-      "tag": "v0.11.0"
+      "version": "0.11.1",
+      "tag": "v0.11.1"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.2.0",
-      "tag": "fatou-formatter-v0.2.0"
+      "version": "0.2.1",
+      "tag": "fatou-formatter-v0.2.1"
     },
     {
       "path": "editors/code",
-      "version": "0.11.0",
-      "tag": "fatou-code-v0.11.0"
+      "version": "0.11.1",
+      "tag": "fatou-code-v0.11.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.11.1](https://github.com/jolars/fatou/compare/v0.11.0...v0.11.1) (2026-08-07)
+
+### Bug Fixes
+- **deps:** require `fatou-parser` 0.1.1 ([`2f6a764`](https://github.com/jolars/fatou/commit/2f6a764f2d21185f8d73677a82b65500e973a6d3))
+
+### Dependencies
+- updated crates/fatou-formatter to v0.2.1
+
 ## [0.11.0](https://github.com/jolars/fatou/compare/v0.10.0...v0.11.0) (2026-08-07)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fatou-parser",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"
@@ -49,7 +49,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5"
 dirs = "6"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.2.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.2.1" }
 fatou-parser = { path = "crates/fatou-parser", version = "0.1.1" }
 globset = "0.4.18"
 ignore = "0.4.26"

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.1](https://github.com/jolars/fatou/compare/fatou-formatter-v0.2.0...fatou-formatter-v0.2.1) (2026-08-07)
+
+### Bug Fixes
+- **deps:** require `fatou-parser` 0.1.1 ([`2f6a764`](https://github.com/jolars/fatou/commit/2f6a764f2d21185f8d73677a82b65500e973a6d3))
+
 ## [0.2.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.1.0...fatou-formatter-v0.2.0) (2026-08-07)
 
 ### Features

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for the Julia language"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.11.1](https://github.com/jolars/fatou/compare/fatou-code-v0.11.0...fatou-code-v0.11.1) (2026-08-07)
+
+### Dependencies
+- updated fatou to v0.11.1
+
 ## [0.11.0](https://github.com/jolars/fatou/compare/fatou-code-v0.10.0...fatou-code-v0.11.0) (2026-08-07)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.11.0",
-    "@fatou-cli/linux-arm64-gnu": "0.11.0",
-    "@fatou-cli/linux-x64-musl": "0.11.0",
-    "@fatou-cli/linux-arm64-musl": "0.11.0",
-    "@fatou-cli/darwin-x64": "0.11.0",
-    "@fatou-cli/darwin-arm64": "0.11.0",
-    "@fatou-cli/win32-x64": "0.11.0",
-    "@fatou-cli/win32-arm64": "0.11.0"
+    "@fatou-cli/linux-x64-gnu": "0.11.1",
+    "@fatou-cli/linux-arm64-gnu": "0.11.1",
+    "@fatou-cli/linux-x64-musl": "0.11.1",
+    "@fatou-cli/linux-arm64-musl": "0.11.1",
+    "@fatou-cli/darwin-x64": "0.11.1",
+    "@fatou-cli/darwin-arm64": "0.11.1",
+    "@fatou-cli/win32-x64": "0.11.1",
+    "@fatou-cli/win32-arm64": "0.11.1"
   }
 }


### PR DESCRIPTION
## [fatou: 0.11.1](https://github.com/jolars/fatou/compare/v0.11.0...v0.11.1) (2026-08-07)

### Bug Fixes
- **deps:** require `fatou-parser` 0.1.1 ([`2f6a764`](https://github.com/jolars/fatou/commit/2f6a764f2d21185f8d73677a82b65500e973a6d3))

### Dependencies
- updated crates/fatou-formatter to v0.2.1

## [crates/fatou-formatter: 0.2.1](https://github.com/jolars/fatou/compare/fatou-formatter-v0.2.0...fatou-formatter-v0.2.1) (2026-08-07)

### Bug Fixes
- **deps:** require `fatou-parser` 0.1.1 ([`2f6a764`](https://github.com/jolars/fatou/commit/2f6a764f2d21185f8d73677a82b65500e973a6d3))

## [editors/code: 0.11.1](https://github.com/jolars/fatou/compare/fatou-code-v0.11.0...fatou-code-v0.11.1) (2026-08-07)

### Dependencies
- updated fatou to v0.11.1

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).