### PR TITLE
chore(release): v0.12.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,38 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ac48a0090e859f1796d3b1531cbc58130ea24946",
+  "baseline-sha": "66fd6bc6b8022875d34f66c98d651aae82fff513",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.11.1",
-      "tag": "v0.11.1"
+      "version": "0.12.0",
+      "tag": "v0.12.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.2.1",
-      "tag": "fatou-formatter-v0.2.1"
+      "version": "0.3.0",
+      "tag": "fatou-formatter-v0.3.0"
+    },
+    {
+      "path": "crates/fatou-parser",
+      "version": "0.2.0",
+      "tag": "fatou-parser-v0.2.0"
     },
     {
       "path": "editors/code",
-      "version": "0.11.1",
-      "tag": "fatou-code-v0.11.1"
+      "version": "0.12.0",
+      "tag": "fatou-code-v0.12.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.11.1",
-      "tag": "v0.11.1"
+      "version": "0.12.0",
+      "tag": "v0.12.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.2.1",
-      "tag": "fatou-formatter-v0.2.1"
+      "version": "0.3.0",
+      "tag": "fatou-formatter-v0.3.0"
+    },
+    {
+      "path": "crates/fatou-parser",
+      "version": "0.2.0",
+      "tag": "fatou-parser-v0.2.0"
     },
     {
       "path": "editors/code",
-      "version": "0.11.1",
-      "tag": "fatou-code-v0.11.1"
+      "version": "0.12.0",
+      "tag": "fatou-code-v0.12.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/fatou/compare/v0.11.1...v0.12.0) (2026-08-07)
+
+### Features
+- **linter:** add `redundant-boolean` ([`66fd6bc`](https://github.com/jolars/fatou/commit/66fd6bc6b8022875d34f66c98d651aae82fff513))
+- **linter:** add `comparison-negation` ([`a7d62bc`](https://github.com/jolars/fatou/commit/a7d62bc8bd9e4c1f1f55a24385c5450577b1f9ed))
+- **linter:** add `length-zero` ([`ec32b98`](https://github.com/jolars/fatou/commit/ec32b98d765fb2766477c854f0d562c99b23dbbf))
+- **linter:** add `typeof-comparison` ([`9226fda`](https://github.com/jolars/fatou/commit/9226fda6a7db289dc2b481a0c22811434a30ac73))
+- **parser:** accept `∈` as iteration separator ([`1f5d8d9`](https://github.com/jolars/fatou/commit/1f5d8d90bf9e7dd55d73e1b71a567870145adde7))
+- **parser:** add `for outer i` iteration spec ([`69c7e2a`](https://github.com/jolars/fatou/commit/69c7e2ac09c64f526726f8148c422c33ac8218ef))
+- **linter:** add `loop-variable-shadow` ([`ba42f66`](https://github.com/jolars/fatou/commit/ba42f66cbf4294a582550e556c2f9d04b8f89fed))
+- **linter:** add `duplicate-method` ([`692ae0e`](https://github.com/jolars/fatou/commit/692ae0e5bbc6b7c9553351ddcba508e4f2f1d004))
+- **linter:** link findings to the rule reference ([`8b5bf31`](https://github.com/jolars/fatou/commit/8b5bf3113194cb431cda3433b052a310c664a61c))
+- **linter:** mark fix applicability in help line ([`deb1b9b`](https://github.com/jolars/fatou/commit/deb1b9b1049f793240dd86dfb88749e3b69003da))
+- **linter:** add `unreachable-code` ([`7495714`](https://github.com/jolars/fatou/commit/74957141cf0006d7f1e6d39af3d8e06353edfa6a))
+- **parser:** end keyword stmt at a generator `for` ([`215ecaf`](https://github.com/jolars/fatou/commit/215ecafeefc507f196ad6729c5ba8be393da252a))
+- **linter:** add `local-const` ([`644a5dd`](https://github.com/jolars/fatou/commit/644a5ddb151d4ee1602b4e96745ebf9856dd845c))
+- **linter:** add `global-const-in-function` ([`c6c2b0a`](https://github.com/jolars/fatou/commit/c6c2b0a35c96cc80a0459b191431349532ddf694))
+- **linter:** add `const-local` ([`2b14b32`](https://github.com/jolars/fatou/commit/2b14b3271d40d76a6ab5bb47121abd28eaa1df0b))
+- **linter:** add `duplicate-keyword-argument` ([`4de42e5`](https://github.com/jolars/fatou/commit/4de42e5c042fa07306466eb051c206b775081b28))
+
+### Bug Fixes
+- **incremental:** shield edited buffers from a sweep ([`94ac7a5`](https://github.com/jolars/fatou/commit/94ac7a5f2dc71d5e1cd6252bbf263c411de3cd43))
+
+### Dependencies
+- updated crates/fatou-formatter to v0.3.0
+- updated crates/fatou-parser to v0.2.0
+
 ## [0.11.1](https://github.com/jolars/fatou/compare/v0.11.0...v0.11.1) (2026-08-07)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "insta",
@@ -584,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fluent-uri"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.11.1"
+version = "0.12.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"
@@ -49,8 +49,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5"
 dirs = "6"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.2.1" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.1.1" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.0" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.2.0" }
 globset = "0.4.18"
 ignore = "0.4.26"
 log = { version = "0.4.32", features = ["release_max_level_info"] }

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.2.1...fatou-formatter-v0.3.0) (2026-08-07)
+
+### Features
+- **parser:** accept `∈` as iteration separator ([`1f5d8d9`](https://github.com/jolars/fatou/commit/1f5d8d90bf9e7dd55d73e1b71a567870145adde7))
+
+### Dependencies
+- updated crates/fatou-parser to v0.2.0
+
 ## [0.2.1](https://github.com/jolars/fatou/compare/fatou-formatter-v0.2.0...fatou-formatter-v0.2.1) (2026-08-07)
 
 ### Bug Fixes

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for the Julia language"
@@ -14,7 +14,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.1.1" }
+fatou-parser = { path = "../fatou-parser", version = "0.2.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.1.1...fatou-parser-v0.2.0) (2026-08-07)
+
+### Features
+- **linter:** add `redundant-boolean` ([`66fd6bc`](https://github.com/jolars/fatou/commit/66fd6bc6b8022875d34f66c98d651aae82fff513))
+- **parser:** accept `∈` as iteration separator ([`1f5d8d9`](https://github.com/jolars/fatou/commit/1f5d8d90bf9e7dd55d73e1b71a567870145adde7))
+- **parser:** add `for outer i` iteration spec ([`69c7e2a`](https://github.com/jolars/fatou/commit/69c7e2ac09c64f526726f8148c422c33ac8218ef))
+- **parser:** end keyword stmt at a generator `for` ([`215ecaf`](https://github.com/jolars/fatou/commit/215ecafeefc507f196ad6729c5ba8be393da252a))

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, typed AST wrappers, and incremental reparser for the Julia language"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/fatou/compare/fatou-code-v0.11.1...fatou-code-v0.12.0) (2026-08-07)
+
+### Dependencies
+- updated fatou to v0.12.0
+
 ## [0.11.1](https://github.com/jolars/fatou/compare/fatou-code-v0.11.0...fatou-code-v0.11.1) (2026-08-07)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.11.1",
-    "@fatou-cli/linux-arm64-gnu": "0.11.1",
-    "@fatou-cli/linux-x64-musl": "0.11.1",
-    "@fatou-cli/linux-arm64-musl": "0.11.1",
-    "@fatou-cli/darwin-x64": "0.11.1",
-    "@fatou-cli/darwin-arm64": "0.11.1",
-    "@fatou-cli/win32-x64": "0.11.1",
-    "@fatou-cli/win32-arm64": "0.11.1"
+    "@fatou-cli/linux-x64-gnu": "0.12.0",
+    "@fatou-cli/linux-arm64-gnu": "0.12.0",
+    "@fatou-cli/linux-x64-musl": "0.12.0",
+    "@fatou-cli/linux-arm64-musl": "0.12.0",
+    "@fatou-cli/darwin-x64": "0.12.0",
+    "@fatou-cli/darwin-arm64": "0.12.0",
+    "@fatou-cli/win32-x64": "0.12.0",
+    "@fatou-cli/win32-arm64": "0.12.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.12.0](https://github.com/jolars/fatou/compare/v0.11.1...v0.12.0) (2026-08-07)

### Features
- **linter:** add `redundant-boolean` ([`66fd6bc`](https://github.com/jolars/fatou/commit/66fd6bc6b8022875d34f66c98d651aae82fff513))
- **linter:** add `comparison-negation` ([`a7d62bc`](https://github.com/jolars/fatou/commit/a7d62bc8bd9e4c1f1f55a24385c5450577b1f9ed))
- **linter:** add `length-zero` ([`ec32b98`](https://github.com/jolars/fatou/commit/ec32b98d765fb2766477c854f0d562c99b23dbbf))
- **linter:** add `typeof-comparison` ([`9226fda`](https://github.com/jolars/fatou/commit/9226fda6a7db289dc2b481a0c22811434a30ac73))
- **parser:** accept `∈` as iteration separator ([`1f5d8d9`](https://github.com/jolars/fatou/commit/1f5d8d90bf9e7dd55d73e1b71a567870145adde7))
- **parser:** add `for outer i` iteration spec ([`69c7e2a`](https://github.com/jolars/fatou/commit/69c7e2ac09c64f526726f8148c422c33ac8218ef))
- **linter:** add `loop-variable-shadow` ([`ba42f66`](https://github.com/jolars/fatou/commit/ba42f66cbf4294a582550e556c2f9d04b8f89fed))
- **linter:** add `duplicate-method` ([`692ae0e`](https://github.com/jolars/fatou/commit/692ae0e5bbc6b7c9553351ddcba508e4f2f1d004))
- **linter:** link findings to the rule reference ([`8b5bf31`](https://github.com/jolars/fatou/commit/8b5bf3113194cb431cda3433b052a310c664a61c))
- **linter:** mark fix applicability in help line ([`deb1b9b`](https://github.com/jolars/fatou/commit/deb1b9b1049f793240dd86dfb88749e3b69003da))
- **linter:** add `unreachable-code` ([`7495714`](https://github.com/jolars/fatou/commit/74957141cf0006d7f1e6d39af3d8e06353edfa6a))
- **parser:** end keyword stmt at a generator `for` ([`215ecaf`](https://github.com/jolars/fatou/commit/215ecafeefc507f196ad6729c5ba8be393da252a))
- **linter:** add `local-const` ([`644a5dd`](https://github.com/jolars/fatou/commit/644a5ddb151d4ee1602b4e96745ebf9856dd845c))
- **linter:** add `global-const-in-function` ([`c6c2b0a`](https://github.com/jolars/fatou/commit/c6c2b0a35c96cc80a0459b191431349532ddf694))
- **linter:** add `const-local` ([`2b14b32`](https://github.com/jolars/fatou/commit/2b14b3271d40d76a6ab5bb47121abd28eaa1df0b))
- **linter:** add `duplicate-keyword-argument` ([`4de42e5`](https://github.com/jolars/fatou/commit/4de42e5c042fa07306466eb051c206b775081b28))

### Bug Fixes
- **incremental:** shield edited buffers from a sweep ([`94ac7a5`](https://github.com/jolars/fatou/commit/94ac7a5f2dc71d5e1cd6252bbf263c411de3cd43))

### Dependencies
- updated crates/fatou-formatter to v0.3.0
- updated crates/fatou-parser to v0.2.0

## [crates/fatou-formatter: 0.3.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.2.1...fatou-formatter-v0.3.0) (2026-08-07)

### Features
- **parser:** accept `∈` as iteration separator ([`1f5d8d9`](https://github.com/jolars/fatou/commit/1f5d8d90bf9e7dd55d73e1b71a567870145adde7))

### Dependencies
- updated crates/fatou-parser to v0.2.0

## [crates/fatou-parser: 0.2.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.1.1...fatou-parser-v0.2.0) (2026-08-07)

### Features
- **linter:** add `redundant-boolean` ([`66fd6bc`](https://github.com/jolars/fatou/commit/66fd6bc6b8022875d34f66c98d651aae82fff513))
- **parser:** accept `∈` as iteration separator ([`1f5d8d9`](https://github.com/jolars/fatou/commit/1f5d8d90bf9e7dd55d73e1b71a567870145adde7))
- **parser:** add `for outer i` iteration spec ([`69c7e2a`](https://github.com/jolars/fatou/commit/69c7e2ac09c64f526726f8148c422c33ac8218ef))
- **parser:** end keyword stmt at a generator `for` ([`215ecaf`](https://github.com/jolars/fatou/commit/215ecafeefc507f196ad6729c5ba8be393da252a))

## [editors/code: 0.12.0](https://github.com/jolars/fatou/compare/fatou-code-v0.11.1...fatou-code-v0.12.0) (2026-08-07)

### Dependencies
- updated fatou to v0.12.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).