### PR TITLE
chore(release): v0.13.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "66fd6bc6b8022875d34f66c98d651aae82fff513",
+  "baseline-sha": "5f900654c8e3d94822d88da77e89cc5c6a06ee21",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.12.0",
-      "tag": "v0.12.0"
+      "version": "0.13.0",
+      "tag": "v0.13.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.0",
-      "tag": "fatou-formatter-v0.3.0"
+      "version": "0.3.1",
+      "tag": "fatou-formatter-v0.3.1"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.2.0",
-      "tag": "fatou-parser-v0.2.0"
+      "version": "0.3.0",
+      "tag": "fatou-parser-v0.3.0"
     },
     {
       "path": "editors/code",
-      "version": "0.12.0",
-      "tag": "fatou-code-v0.12.0"
+      "version": "0.13.0",
+      "tag": "fatou-code-v0.13.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.12.0",
-      "tag": "v0.12.0"
+      "version": "0.13.0",
+      "tag": "v0.13.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.0",
-      "tag": "fatou-formatter-v0.3.0"
+      "version": "0.3.1",
+      "tag": "fatou-formatter-v0.3.1"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.2.0",
-      "tag": "fatou-parser-v0.2.0"
+      "version": "0.3.0",
+      "tag": "fatou-parser-v0.3.0"
     },
     {
       "path": "editors/code",
-      "version": "0.12.0",
-      "tag": "fatou-code-v0.12.0"
+      "version": "0.13.0",
+      "tag": "fatou-code-v0.13.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/fatou/compare/v0.12.0...v0.13.0) (2026-08-09)
+
+### Features
+- **bench:** add a language-server memory benchmark ([`599e8e5`](https://github.com/jolars/fatou/commit/599e8e5e338918785ba5895f6df5dac3c2b99ec4))
+- **linter:** add `shadowed-base-name` ([`edd3170`](https://github.com/jolars/fatou/commit/edd31706eec851264f15646042f93e325b2800c5))
+- **linter:** add `function-has-no-methods` ([`f756c7c`](https://github.com/jolars/fatou/commit/f756c7c3dd6d64373bbc87c58e3b8bfdc09f5ef9))
+- **linter:** add `kwarg-default-mismatch` ([`d395287`](https://github.com/jolars/fatou/commit/d395287312b79f57a77a4895d207bd3ee4a8e252))
+- **lsp:** rename files and folders ([`427427e`](https://github.com/jolars/fatou/commit/427427e0d346ec99526730998e8b33f9d5b06db2))
+- **linter:** add `unresolved-import` ([`7c6bd5b`](https://github.com/jolars/fatou/commit/7c6bd5b717040e775d51f58d3fe91160f09d6232))
+
+### Bug Fixes
+- **linter:** keep type args in duplicate-method identity ([`02c3f6d`](https://github.com/jolars/fatou/commit/02c3f6de70fabd0b45f18438ede9d1161b468964)), closes [#75](https://github.com/jolars/fatou/issues/75)
+
+### Dependencies
+- updated crates/fatou-parser to v0.3.0
+
 ## [0.12.0](https://github.com/jolars/fatou/compare/v0.11.1...v0.12.0) (2026-08-07)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "insta",
@@ -965,9 +965,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1433,18 +1433,18 @@ checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"
@@ -49,8 +49,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5"
 dirs = "6"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.0" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.2.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.1" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.3.0" }
 globset = "0.4.18"
 ignore = "0.4.26"
 log = { version = "0.4.32", features = ["release_max_level_info"] }

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.1](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.0...fatou-formatter-v0.3.1) (2026-08-09)
+
+### Dependencies
+- updated crates/fatou-parser to v0.3.0
+
 ## [0.3.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.2.1...fatou-formatter-v0.3.0) (2026-08-07)
 
 ### Features

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for the Julia language"
@@ -14,7 +14,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.2.0" }
+fatou-parser = { path = "../fatou-parser", version = "0.3.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.2.0...fatou-parser-v0.3.0) (2026-08-09)
+
+### Features
+- **linter:** add `kwarg-default-mismatch` ([`d395287`](https://github.com/jolars/fatou/commit/d395287312b79f57a77a4895d207bd3ee4a8e252))
+
 ## [0.2.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.1.1...fatou-parser-v0.2.0) (2026-08-07)
 
 ### Features

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, typed AST wrappers, and incremental reparser for the Julia language"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/fatou/compare/fatou-code-v0.12.0...fatou-code-v0.13.0) (2026-08-09)
+
+### Dependencies
+- updated fatou to v0.13.0
+
 ## [0.12.0](https://github.com/jolars/fatou/compare/fatou-code-v0.11.1...fatou-code-v0.12.0) (2026-08-07)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.12.0",
-    "@fatou-cli/linux-arm64-gnu": "0.12.0",
-    "@fatou-cli/linux-x64-musl": "0.12.0",
-    "@fatou-cli/linux-arm64-musl": "0.12.0",
-    "@fatou-cli/darwin-x64": "0.12.0",
-    "@fatou-cli/darwin-arm64": "0.12.0",
-    "@fatou-cli/win32-x64": "0.12.0",
-    "@fatou-cli/win32-arm64": "0.12.0"
+    "@fatou-cli/linux-x64-gnu": "0.13.0",
+    "@fatou-cli/linux-arm64-gnu": "0.13.0",
+    "@fatou-cli/linux-x64-musl": "0.13.0",
+    "@fatou-cli/linux-arm64-musl": "0.13.0",
+    "@fatou-cli/darwin-x64": "0.13.0",
+    "@fatou-cli/darwin-arm64": "0.13.0",
+    "@fatou-cli/win32-x64": "0.13.0",
+    "@fatou-cli/win32-arm64": "0.13.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.13.0](https://github.com/jolars/fatou/compare/v0.12.0...v0.13.0) (2026-08-09)

### Features
- **bench:** add a language-server memory benchmark ([`599e8e5`](https://github.com/jolars/fatou/commit/599e8e5e338918785ba5895f6df5dac3c2b99ec4))
- **linter:** add `shadowed-base-name` ([`edd3170`](https://github.com/jolars/fatou/commit/edd31706eec851264f15646042f93e325b2800c5))
- **linter:** add `function-has-no-methods` ([`f756c7c`](https://github.com/jolars/fatou/commit/f756c7c3dd6d64373bbc87c58e3b8bfdc09f5ef9))
- **linter:** add `kwarg-default-mismatch` ([`d395287`](https://github.com/jolars/fatou/commit/d395287312b79f57a77a4895d207bd3ee4a8e252))
- **lsp:** rename files and folders ([`427427e`](https://github.com/jolars/fatou/commit/427427e0d346ec99526730998e8b33f9d5b06db2))
- **linter:** add `unresolved-import` ([`7c6bd5b`](https://github.com/jolars/fatou/commit/7c6bd5b717040e775d51f58d3fe91160f09d6232))

### Bug Fixes
- **linter:** keep type args in duplicate-method identity ([`02c3f6d`](https://github.com/jolars/fatou/commit/02c3f6de70fabd0b45f18438ede9d1161b468964)), closes [#75](https://github.com/jolars/fatou/issues/75)

### Dependencies
- updated crates/fatou-parser to v0.3.0

## [crates/fatou-formatter: 0.3.1](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.0...fatou-formatter-v0.3.1) (2026-08-09)

### Dependencies
- updated crates/fatou-parser to v0.3.0

## [crates/fatou-parser: 0.3.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.2.0...fatou-parser-v0.3.0) (2026-08-09)

### Features
- **linter:** add `kwarg-default-mismatch` ([`d395287`](https://github.com/jolars/fatou/commit/d395287312b79f57a77a4895d207bd3ee4a8e252))

## [editors/code: 0.13.0](https://github.com/jolars/fatou/compare/fatou-code-v0.12.0...fatou-code-v0.13.0) (2026-08-09)

### Dependencies
- updated fatou to v0.13.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).