### PR TITLE
chore(release): v0.14.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5f900654c8e3d94822d88da77e89cc5c6a06ee21",
+  "baseline-sha": "aff9bd03b5073b0602e0118f50444e00e6d307e7",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.1",
-      "tag": "fatou-formatter-v0.3.1"
+      "version": "0.3.2",
+      "tag": "fatou-formatter-v0.3.2"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.3.0",
-      "tag": "fatou-parser-v0.3.0"
+      "version": "0.4.0",
+      "tag": "fatou-parser-v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.13.0",
-      "tag": "fatou-code-v0.13.0"
+      "version": "0.14.0",
+      "tag": "fatou-code-v0.14.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.1",
-      "tag": "fatou-formatter-v0.3.1"
+      "version": "0.3.2",
+      "tag": "fatou-formatter-v0.3.2"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.3.0",
-      "tag": "fatou-parser-v0.3.0"
+      "version": "0.4.0",
+      "tag": "fatou-parser-v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.13.0",
-      "tag": "fatou-code-v0.13.0"
+      "version": "0.14.0",
+      "tag": "fatou-code-v0.14.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/fatou/compare/v0.13.0...v0.14.0) (2026-08-13)
+
+### Features
+- **lsp:** ask the client to re-request inlay hints ([`e909f9f`](https://github.com/jolars/fatou/commit/e909f9ffa1927f2013e5296ef27e4bce09536c91))
+- **lsp:** link a manifest's dev'd path entries ([`be3ec4a`](https://github.com/jolars/fatou/commit/be3ec4a96c4ac4a88d9787c5c27cb83460c46ba9))
+- **lsp:** show a dependency's resolved version inline ([`085e9c6`](https://github.com/jolars/fatou/commit/085e9c60acca9330afc88f8636d45e157520593a))
+- **lsp:** link dependency names to their package ([`8edc445`](https://github.com/jolars/fatou/commit/8edc445734dd87128657e74085f591a3d748ad7a))
+- **lsp:** hover a dependency for its version and path ([`4d77049`](https://github.com/jolars/fatou/commit/4d770497ea1b6b153e3bf6f02355e435352a0ac3))
+- **lsp:** go to a dependency's source from a project file ([`f6fe8a1`](https://github.com/jolars/fatou/commit/f6fe8a1d7a668f32407e390ad3014783a3bdf06d))
+- **index:** locate a project file's dependency entries ([`cdd07e3`](https://github.com/jolars/fatou/commit/cdd07e3ce5ae57f34c9a554bf80acdcdf6807c7d))
+- **lsp:** give an open project file its own route ([`f51a483`](https://github.com/jolars/fatou/commit/f51a483a69f4e26de7881b3fe3c62bac0f67b760))
+- **lsp:** feed an open project file to the database ([`95acc26`](https://github.com/jolars/fatou/commit/95acc264097f7f4a081feec166e4de954d7a9152))
+- **incremental:** derive declared deps from the project file ([`9688be0`](https://github.com/jolars/fatou/commit/9688be0330ae1a2fb43714a8862704db18dceb17))
+- **index:** record each workspace project file's path ([`1b31ae3`](https://github.com/jolars/fatou/commit/1b31ae303c413461366232e0a30c122702035921))
+- **env:** name a project's declared dependencies once ([`abd60d1`](https://github.com/jolars/fatou/commit/abd60d1b404a382e3e6c9bb733e0bb1527149531))
+- **index:** add the six project-file semantic checks ([`687fe63`](https://github.com/jolars/fatou/commit/687fe63c11a7cc2924a5da7ac9f02da23a67f387))
+- **lsp:** publish project-file diagnostics from the harvester ([`dff678f`](https://github.com/jolars/fatou/commit/dff678f665cfe740787385a1d50380d9aba737a5))
+- **index:** add project-file syntax checks ([`244efd3`](https://github.com/jolars/fatou/commit/244efd39e583159b214abd058e3e78ceff4e7ea0))
+- **linter:** add the `unnecessary-nesting` rule ([`17a8008`](https://github.com/jolars/fatou/commit/17a80086f259a5c8724f0d475de9311203c7abc7))
+- **linter:** flag a fixed regex in every pattern position ([`d0b5c93`](https://github.com/jolars/fatou/commit/d0b5c93634df42539c52d841ec8e9f90f3a265c3))
+- **linter:** read `contains` in the regex-literal rules ([`4da0bb6`](https://github.com/jolars/fatou/commit/4da0bb612c1b090c833395ad6364b698b494551c))
+- **linter:** add the occursin regex-literal rules ([`c33ee54`](https://github.com/jolars/fatou/commit/c33ee547e2ae957b7eaa700067fc293ef10d7422))
+- **linter:** add the eager-broadcast rule family ([`9a49535`](https://github.com/jolars/fatou/commit/9a4953573d63841bde6a9dfc8aa5188b458a29d6))
+- **linter:** add `invalid-type-declaration` ([`79c51b8`](https://github.com/jolars/fatou/commit/79c51b8e3d76dbd571f1b20764c8c1b4f782431a))
+- **linter:** add the suppression meta-rule family ([`fb8aa07`](https://github.com/jolars/fatou/commit/fb8aa07ec7fef4c7974d891ac3c4973ba005369b))
+- **cli:** read stdin from `-`, not a bare terminal ([`ffb0982`](https://github.com/jolars/fatou/commit/ffb09825c36e3ad91ebd68b2bfa35a31b7bbb862))
+- **linter:** add `non-public-access` ([`2b5bef6`](https://github.com/jolars/fatou/commit/2b5bef68176e5d97076cb914c5a854dd81c7c123))
+
+### Bug Fixes
+- **lsp:** never route a `.toml` through the Julia parser ([`dfcff18`](https://github.com/jolars/fatou/commit/dfcff18d1390f146c6f896b2238315139b9d2ec0))
+- **lsp:** sync a watched project file to disk ([`b2ffbd4`](https://github.com/jolars/fatou/commit/b2ffbd47cc2f6a4c3915ef22d49d013aa6422b54))
+- **lsp:** normalize a definition target's path ([`ac5ebfa`](https://github.com/jolars/fatou/commit/ac5ebfa813eeebf852392105ad065f76954489b2))
+- **lsp:** refresh open documents for push clients too ([`ee66f81`](https://github.com/jolars/fatou/commit/ee66f815d12091d325b2273af72760d9e3be33a8))
+- **lsp:** never parse an environment file as Julia ([`094e96d`](https://github.com/jolars/fatou/commit/094e96dd7648b8e5b9d71939ea08f8ceecfe2387))
+- **lsp:** repair the windows-gated rename test ([`852b169`](https://github.com/jolars/fatou/commit/852b169271cb6402efcb989b87488b43c0de8892))
+- **project:** decode string escapes in include paths ([`2c0854d`](https://github.com/jolars/fatou/commit/2c0854d851ee57dc1acb1f2e004c8a4d329a7e73))
+
+### Performance Improvements
+- **lsp:** ignore a project file no package claims ([`89b6e97`](https://github.com/jolars/fatou/commit/89b6e970d42f5ba39345ae8d554e3ad0d0c5ac44))
+- **lsp:** share one line table across a document's readers ([`a054ecf`](https://github.com/jolars/fatou/commit/a054ecf6807390764132d98ed829bc892bf683bb)), closes [#76](https://github.com/jolars/fatou/issues/76)
+- **lsp:** patch the line table across edits ([`6f949d5`](https://github.com/jolars/fatou/commit/6f949d5d3c9311a6f44b636fb83b0fa71d3f401b)), refs [#76](https://github.com/jolars/fatou/issues/76)
+
+### Dependencies
+- updated crates/fatou-formatter to v0.3.2
+- updated crates/fatou-parser to v0.4.0
+
 ## [0.13.0](https://github.com/jolars/fatou/compare/v0.12.0...v0.13.0) (2026-08-09)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -264,9 +264,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c630ddc90572b3d9abd3f887f0007b4e048faf5c5a59ae607f8ac1c5e3790873"
+checksum = "211d617eaa4b735c96c9e0228fcbdb5120ef623f2b8cb67ffb84c3e02dbc28a4"
 dependencies = [
  "clap",
  "roff",
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"
@@ -49,8 +49,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.1" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.3.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.2" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.4.0" }
 globset = "0.4.18"
 ignore = "0.4.26"
 log = { version = "0.4.32", features = ["release_max_level_info"] }

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.1...fatou-formatter-v0.3.2) (2026-08-13)
+
+### Dependencies
+- updated crates/fatou-parser to v0.4.0
+
 ## [0.3.1](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.0...fatou-formatter-v0.3.1) (2026-08-09)
 
 ### Dependencies

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for the Julia language"
@@ -14,7 +14,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.3.0" }
+fatou-parser = { path = "../fatou-parser", version = "0.4.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.3.0...fatou-parser-v0.4.0) (2026-08-13)
+
+### Features
+- **parser:** expose `string_value` for literal decoding ([`e4c4529`](https://github.com/jolars/fatou/commit/e4c45299c6cf0cf4829efcefb8163262f19982dd))
+
 ## [0.3.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.2.0...fatou-parser-v0.3.0) (2026-08-09)
 
 ### Features

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, typed AST wrappers, and incremental reparser for the Julia language"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/fatou/compare/fatou-code-v0.13.0...fatou-code-v0.14.0) (2026-08-13)
+
+### Features
+- **code:** gate inlay hints with the other language features ([`ee3bc08`](https://github.com/jolars/fatou/commit/ee3bc08bd0fb2b41bb7b94148a1b390ce746771c))
+- **code:** attach the server to Julia's environment files ([`cc84d78`](https://github.com/jolars/fatou/commit/cc84d780c5a8e36d3a89112bf99684200b8b922e))
+
+### Bug Fixes
+- **code:** require a digit in the versioned manifest glob ([`895ebba`](https://github.com/jolars/fatou/commit/895ebbae5402e60731b394eacd581fd39ff89a89))
+
+### Dependencies
+- updated fatou to v0.14.0
+
 ## [0.13.0](https://github.com/jolars/fatou/compare/fatou-code-v0.12.0...fatou-code-v0.13.0) (2026-08-09)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.13.0",
-    "@fatou-cli/linux-arm64-gnu": "0.13.0",
-    "@fatou-cli/linux-x64-musl": "0.13.0",
-    "@fatou-cli/linux-arm64-musl": "0.13.0",
-    "@fatou-cli/darwin-x64": "0.13.0",
-    "@fatou-cli/darwin-arm64": "0.13.0",
-    "@fatou-cli/win32-x64": "0.13.0",
-    "@fatou-cli/win32-arm64": "0.13.0"
+    "@fatou-cli/linux-x64-gnu": "0.14.0",
+    "@fatou-cli/linux-arm64-gnu": "0.14.0",
+    "@fatou-cli/linux-x64-musl": "0.14.0",
+    "@fatou-cli/linux-arm64-musl": "0.14.0",
+    "@fatou-cli/darwin-x64": "0.14.0",
+    "@fatou-cli/darwin-arm64": "0.14.0",
+    "@fatou-cli/win32-x64": "0.14.0",
+    "@fatou-cli/win32-arm64": "0.14.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.14.0](https://github.com/jolars/fatou/compare/v0.13.0...v0.14.0) (2026-08-13)

### Features
- **lsp:** ask the client to re-request inlay hints ([`e909f9f`](https://github.com/jolars/fatou/commit/e909f9ffa1927f2013e5296ef27e4bce09536c91))
- **lsp:** link a manifest's dev'd path entries ([`be3ec4a`](https://github.com/jolars/fatou/commit/be3ec4a96c4ac4a88d9787c5c27cb83460c46ba9))
- **lsp:** show a dependency's resolved version inline ([`085e9c6`](https://github.com/jolars/fatou/commit/085e9c60acca9330afc88f8636d45e157520593a))
- **lsp:** link dependency names to their package ([`8edc445`](https://github.com/jolars/fatou/commit/8edc445734dd87128657e74085f591a3d748ad7a))
- **lsp:** hover a dependency for its version and path ([`4d77049`](https://github.com/jolars/fatou/commit/4d770497ea1b6b153e3bf6f02355e435352a0ac3))
- **lsp:** go to a dependency's source from a project file ([`f6fe8a1`](https://github.com/jolars/fatou/commit/f6fe8a1d7a668f32407e390ad3014783a3bdf06d))
- **index:** locate a project file's dependency entries ([`cdd07e3`](https://github.com/jolars/fatou/commit/cdd07e3ce5ae57f34c9a554bf80acdcdf6807c7d))
- **lsp:** give an open project file its own route ([`f51a483`](https://github.com/jolars/fatou/commit/f51a483a69f4e26de7881b3fe3c62bac0f67b760))
- **lsp:** feed an open project file to the database ([`95acc26`](https://github.com/jolars/fatou/commit/95acc264097f7f4a081feec166e4de954d7a9152))
- **incremental:** derive declared deps from the project file ([`9688be0`](https://github.com/jolars/fatou/commit/9688be0330ae1a2fb43714a8862704db18dceb17))
- **index:** record each workspace project file's path ([`1b31ae3`](https://github.com/jolars/fatou/commit/1b31ae303c413461366232e0a30c122702035921))
- **env:** name a project's declared dependencies once ([`abd60d1`](https://github.com/jolars/fatou/commit/abd60d1b404a382e3e6c9bb733e0bb1527149531))
- **index:** add the six project-file semantic checks ([`687fe63`](https://github.com/jolars/fatou/commit/687fe63c11a7cc2924a5da7ac9f02da23a67f387))
- **lsp:** publish project-file diagnostics from the harvester ([`dff678f`](https://github.com/jolars/fatou/commit/dff678f665cfe740787385a1d50380d9aba737a5))
- **index:** add project-file syntax checks ([`244efd3`](https://github.com/jolars/fatou/commit/244efd39e583159b214abd058e3e78ceff4e7ea0))
- **linter:** add the `unnecessary-nesting` rule ([`17a8008`](https://github.com/jolars/fatou/commit/17a80086f259a5c8724f0d475de9311203c7abc7))
- **linter:** flag a fixed regex in every pattern position ([`d0b5c93`](https://github.com/jolars/fatou/commit/d0b5c93634df42539c52d841ec8e9f90f3a265c3))
- **linter:** read `contains` in the regex-literal rules ([`4da0bb6`](https://github.com/jolars/fatou/commit/4da0bb612c1b090c833395ad6364b698b494551c))
- **linter:** add the occursin regex-literal rules ([`c33ee54`](https://github.com/jolars/fatou/commit/c33ee547e2ae957b7eaa700067fc293ef10d7422))
- **linter:** add the eager-broadcast rule family ([`9a49535`](https://github.com/jolars/fatou/commit/9a4953573d63841bde6a9dfc8aa5188b458a29d6))
- **linter:** add `invalid-type-declaration` ([`79c51b8`](https://github.com/jolars/fatou/commit/79c51b8e3d76dbd571f1b20764c8c1b4f782431a))
- **linter:** add the suppression meta-rule family ([`fb8aa07`](https://github.com/jolars/fatou/commit/fb8aa07ec7fef4c7974d891ac3c4973ba005369b))
- **cli:** read stdin from `-`, not a bare terminal ([`ffb0982`](https://github.com/jolars/fatou/commit/ffb09825c36e3ad91ebd68b2bfa35a31b7bbb862))
- **linter:** add `non-public-access` ([`2b5bef6`](https://github.com/jolars/fatou/commit/2b5bef68176e5d97076cb914c5a854dd81c7c123))

### Bug Fixes
- **lsp:** never route a `.toml` through the Julia parser ([`dfcff18`](https://github.com/jolars/fatou/commit/dfcff18d1390f146c6f896b2238315139b9d2ec0))
- **lsp:** sync a watched project file to disk ([`b2ffbd4`](https://github.com/jolars/fatou/commit/b2ffbd47cc2f6a4c3915ef22d49d013aa6422b54))
- **lsp:** normalize a definition target's path ([`ac5ebfa`](https://github.com/jolars/fatou/commit/ac5ebfa813eeebf852392105ad065f76954489b2))
- **lsp:** refresh open documents for push clients too ([`ee66f81`](https://github.com/jolars/fatou/commit/ee66f815d12091d325b2273af72760d9e3be33a8))
- **lsp:** never parse an environment file as Julia ([`094e96d`](https://github.com/jolars/fatou/commit/094e96dd7648b8e5b9d71939ea08f8ceecfe2387))
- **lsp:** repair the windows-gated rename test ([`852b169`](https://github.com/jolars/fatou/commit/852b169271cb6402efcb989b87488b43c0de8892))
- **project:** decode string escapes in include paths ([`2c0854d`](https://github.com/jolars/fatou/commit/2c0854d851ee57dc1acb1f2e004c8a4d329a7e73))

### Performance Improvements
- **lsp:** ignore a project file no package claims ([`89b6e97`](https://github.com/jolars/fatou/commit/89b6e970d42f5ba39345ae8d554e3ad0d0c5ac44))
- **lsp:** share one line table across a document's readers ([`a054ecf`](https://github.com/jolars/fatou/commit/a054ecf6807390764132d98ed829bc892bf683bb)), closes [#76](https://github.com/jolars/fatou/issues/76)
- **lsp:** patch the line table across edits ([`6f949d5`](https://github.com/jolars/fatou/commit/6f949d5d3c9311a6f44b636fb83b0fa71d3f401b)), refs [#76](https://github.com/jolars/fatou/issues/76)

### Dependencies
- updated crates/fatou-formatter to v0.3.2
- updated crates/fatou-parser to v0.4.0

## [crates/fatou-formatter: 0.3.2](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.1...fatou-formatter-v0.3.2) (2026-08-13)

### Dependencies
- updated crates/fatou-parser to v0.4.0

## [crates/fatou-parser: 0.4.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.3.0...fatou-parser-v0.4.0) (2026-08-13)

### Features
- **parser:** expose `string_value` for literal decoding ([`e4c4529`](https://github.com/jolars/fatou/commit/e4c45299c6cf0cf4829efcefb8163262f19982dd))

## [editors/code: 0.14.0](https://github.com/jolars/fatou/compare/fatou-code-v0.13.0...fatou-code-v0.14.0) (2026-08-13)

### Features
- **code:** gate inlay hints with the other language features ([`ee3bc08`](https://github.com/jolars/fatou/commit/ee3bc08bd0fb2b41bb7b94148a1b390ce746771c))
- **code:** attach the server to Julia's environment files ([`cc84d78`](https://github.com/jolars/fatou/commit/cc84d780c5a8e36d3a89112bf99684200b8b922e))

### Bug Fixes
- **code:** require a digit in the versioned manifest glob ([`895ebba`](https://github.com/jolars/fatou/commit/895ebbae5402e60731b394eacd581fd39ff89a89))

### Dependencies
- updated fatou to v0.14.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).