### PR TITLE
feat(lsp): diagnostics and navigation for Julia's project files

### DIFF
--- a/.claude/rules/index.md
+++ b/.claude/rules/index.md
@@ -79,6 +79,12 @@ re-resolve cannot clobber an open, unsaved file — which means a re-resolve is
 exactly as it does a `.jl` source. Drop that and a `pkg> add` from a terminal
 leaves `unresolved-import` answering to the text the file had at startup.
 
+An editor also opens project files belonging to **no** package — a
+`docs/Project.toml`, a depot one followed from a manifest link. Their text is
+tracked like any other buffer, but `declared_deps_of_file` answers `None` for
+them: nothing reads their `[deps]`, and a keystroke there must not re-lint the
+workspace.
+
 ## Testing
 
 Suites live at the root: `harvest.rs`, `base_index.rs`, `library_index.rs`,

--- a/.claude/rules/index.md
+++ b/.claude/rules/index.md
@@ -56,10 +56,20 @@ install (dropping gensym names containing `#`); never hand-edit.
 
 ## Declared dependencies
 
-`HarvestedLibrary::declared_deps` is read from each workspace package's
-`Project.toml` `[deps]` and is deliberately **not derived from the harvest**: a
-project that was never instantiated, or one whose Julia install fatou could not
-locate, still declares its dependencies. That is what `unresolved-import` reads.
+A workspace package's declared dependencies are its `Project.toml` `[deps]`
+names, and are deliberately **not derived from the harvest**: a project that was
+never instantiated, or one whose Julia install fatou could not locate, still
+declares its dependencies. That is what `unresolved-import` reads.
+
+`ProjectFile::declared_dep_names` is the **one** definition, unfiltered by
+whether the paired UUID parses. Two consumers share it, and they must not
+drift: the CLI through `Environment::declared_deps` →
+`HarvestedLibrary::declared_deps` (no salsa db, no buffer to be stale against),
+and the language server through the `project_declared_deps` salsa query, keyed
+on the project file's own `SourceFile` input (`HarvestedLibrary::project_files`
+supplies the paths). The server's route is what makes an **unsaved** `[deps]`
+edit count — the `Project.toml` buffer is authoritative there, while everything
+needing a resolved `Environment` stays on the harvester's save cadence.
 
 ## Testing
 

--- a/.claude/rules/index.md
+++ b/.claude/rules/index.md
@@ -71,6 +71,14 @@ supplies the paths). The server's route is what makes an **unsaved** `[deps]`
 edit count — the `Project.toml` buffer is authoritative there, while everything
 needing a resolved `Environment` stays on the harvester's save cadence.
 
+The buffer is authoritative only **while a buffer exists**. `set_project_files`
+seeds through `seed_disk_file`, which is create-or-return precisely so a
+re-resolve cannot clobber an open, unsaved file — which means a re-resolve is
+*not* what refreshes a closed one. The **watched-file sync** is:
+`on_watched_files` reverts an environment file with no open document to disk,
+exactly as it does a `.jl` source. Drop that and a `pkg> add` from a terminal
+leaves `unresolved-import` answering to the text the file had at startup.
+
 ## Testing
 
 Suites live at the root: `harvest.rs`, `base_index.rs`, `library_index.rs`,

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -78,13 +78,17 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
 - **An open document is not always Julia.** `Document` carries a
   `DocumentKind`, tagged once at `didOpen`; the environment files
   (`Project.toml`, `Manifest.toml`, and friends) are in the client's document
-  selector, so any request can arrive for one. Reach a buffer for a language
-  feature through `GlobalState::julia_text`, never `documents` directly — a
-  hover or a format served off a TOML buffer parses it as Julia. Their own
-  diagnostics have **two producers**: the buffer (text-only checks, edit
-  cadence) and the harvester (a resolved `Environment`, resolve cadence). The
-  buffer's set supersedes rather than joins — `publish_merged` is the one place
-  that merge lives.
+  selector, so any request can arrive for one. **Reach a buffer through
+  `GlobalState::julia_text` or `project_text`, never `documents` directly** —
+  those two are the only doors into the read pool. A Julia-backed feature asks
+  `julia_text` and answers `null` otherwise, because a hover or a format served
+  off a TOML buffer parses it as Julia; a feature that understands TOML asks
+  `project_text` and lands in `project_navigation.rs`. A `Manifest.toml`
+  answers neither: its text never reaches the database, and it carries no spans
+  to anchor on. Their own diagnostics have **two producers**: the buffer
+  (text-only checks, edit cadence) and the harvester (a resolved `Environment`,
+  resolve cadence). The buffer's set supersedes rather than joins —
+  `publish_merged` is the one place that merge lives.
 - A setting that is a fact about the **machine** belongs in editor settings
   (`config.rs`), not `fatou.toml`; project facts belong in the config file. The
   LSP resolves `fatou.toml` the same way the CLI does so both walks honor the

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -75,6 +75,16 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
 - `latex_symbols.rs` is **generated** by `scripts/generate-latex-symbols.jl`
   from `REPL.REPLCompletions`; regenerate on a Julia bump, do not hand-edit.
   Both tables are sorted by key and `completion.rs` binary-searches them.
+- **An open document is not always Julia.** `Document` carries a
+  `DocumentKind`, tagged once at `didOpen`; the environment files
+  (`Project.toml`, `Manifest.toml`, and friends) are in the client's document
+  selector, so any request can arrive for one. Reach a buffer for a language
+  feature through `GlobalState::julia_text`, never `documents` directly — a
+  hover or a format served off a TOML buffer parses it as Julia. Their own
+  diagnostics have **two producers**: the buffer (text-only checks, edit
+  cadence) and the harvester (a resolved `Environment`, resolve cadence). The
+  buffer's set supersedes rather than joins — `publish_merged` is the one place
+  that merge lives.
 - A setting that is a fact about the **machine** belongs in editor settings
   (`config.rs`), not `fatou.toml`; project facts belong in the config file. The
   LSP resolves `fatou.toml` the same way the CLI does so both walks honor the

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -91,6 +91,12 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
   (text-only checks, edit cadence) and the harvester (a resolved `Environment`,
   resolve cadence). The buffer's set supersedes rather than joins —
   `publish_merged` is the one place that merge lives.
+- **A feature the harvest feeds needs a refresh nudge.** The library lands
+  seconds after `initialize`, and a client re-requests hints only on an edit or
+  a scroll, so a full harvest sends `workspace/inlayHint/refresh` (guarded by
+  the client capability, as `workspace/diagnostic/refresh` is). Anything else
+  reading the library from an already-open document has the same gap and the
+  same fix — bar document links, which the spec gives no refresh request.
 - A setting that is a fact about the **machine** belongs in editor settings
   (`config.rs`), not `fatou.toml`; project facts belong in the config file. The
   LSP resolves `fatou.toml` the same way the CLI does so both walks honor the

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -80,7 +80,11 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
   (`Project.toml`, `Manifest.toml`, and friends) are in the client's document
   selector, so any request can arrive for one. **Reach a buffer through
   `GlobalState::julia_text`, `project_text`, or `manifest_text`, never
-  `documents` directly** — those three are the only doors into the read pool. A
+  `documents` directly** — those three are the only doors into the read pool.
+  A `.toml` is **never** Julia: the two environment flavors get their routes and
+  every other one is `DocumentKind::Other`, which answers nothing, so a client
+  selector matching one file too many costs an ignored document rather than a
+  TOML file in the Julia parser. A
   Julia-backed feature asks `julia_text` and answers `null` otherwise, because a
   hover or a format served off a TOML buffer parses it as Julia; a feature that
   understands TOML asks `project_text` and lands in `project_navigation.rs`. A

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -79,13 +79,15 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
   `DocumentKind`, tagged once at `didOpen`; the environment files
   (`Project.toml`, `Manifest.toml`, and friends) are in the client's document
   selector, so any request can arrive for one. **Reach a buffer through
-  `GlobalState::julia_text` or `project_text`, never `documents` directly** —
-  those two are the only doors into the read pool. A Julia-backed feature asks
-  `julia_text` and answers `null` otherwise, because a hover or a format served
-  off a TOML buffer parses it as Julia; a feature that understands TOML asks
-  `project_text` and lands in `project_navigation.rs`. A `Manifest.toml`
-  answers neither: its text never reaches the database, and it carries no spans
-  to anchor on. Their own diagnostics have **two producers**: the buffer
+  `GlobalState::julia_text`, `project_text`, or `manifest_text`, never
+  `documents` directly** — those three are the only doors into the read pool. A
+  Julia-backed feature asks `julia_text` and answers `null` otherwise, because a
+  hover or a format served off a TOML buffer parses it as Julia; a feature that
+  understands TOML asks `project_text` and lands in `project_navigation.rs`. A
+  `Manifest.toml` answers **one** request, `documentLink` on its `path` entries,
+  which needs neither the library nor the database — everything that does need a
+  resolved environment stops at that door, since a manifest's text never reaches
+  the database. Their own diagnostics have **two producers**: the buffer
   (text-only checks, edit cadence) and the harvester (a resolved `Environment`,
   resolve cadence). The buffer's set supersedes rather than joins —
   `publish_merged` is the one place that merge lives.

--- a/.claude/rules/semantic.md
+++ b/.claude/rules/semantic.md
@@ -70,6 +70,12 @@ visible name in the same order with shadowed names dropped, for completion.
 - `src/incremental.rs` models file text → CST → semantic model → resolution as
   salsa queries. The parser crate itself stays salsa-free.
 - **Store green nodes in salsa, never red** (`SyntaxNode` is not `Send`/`Eq`).
+- **The firewall runs both ways.** A `Project.toml` is an ordinary `SourceFile`
+  input, so `[deps]` follows an unsaved buffer; `project_declared_deps` is what
+  keeps that from costing anything, and the same test file guards that a
+  project-file edit re-parses no Julia. Only the name → input *mapping*
+  (`ProjectFiles`) is HIGH durability — putting the text there would be the
+  mirror of adding a range to a projection.
 - Whole-value leaves (`LibraryPackages` and friends) wrap their maps so the
   model types stay salsa-free and each value is an `Arc` — replacing one package
   clones only pointers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,8 @@ matching `.claude/rules/` file.
   project/depot the way Julia's loader does. Falls back to a baked-in Base/Core
   export list when no install is found.
 - **Project files** (`src/project_files.rs`) — checks over `Project.toml`/
-  `Manifest.toml` *themselves*, published by the LSP on the file at fault.
+  `Manifest.toml` *themselves*, published by the LSP on the file at fault, plus
+  the dependency entries an open one navigates by (`dep_entries`/`dep_at`).
   **Not lint rules** (there is no `SyntaxKind` to dispatch on) and deliberately
   LSP-free, so the mapping to `lsp_types` stays at the edge.
 - **Linter** (`src/linter/`) — **purely semantic**; anything `format --check`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ and type hierarchy, signature help, code actions, folding and selection ranges,
 document links, and semantic tokens, alongside formatting (whole-document and
 range) and diagnostics (push and pull). It checks your `Project.toml` and
 `Manifest.toml` themselves too, and navigates an open `Project.toml`'s
-dependency names.
+dependency names, with each one's resolved version shown as an inlay hint.
 
 The **Fatou** extension for VS Code and Open VSX
 ([Marketplace](https://marketplace.visualstudio.com/items?itemName=jolars.fatou),

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ highlights, rename (of symbols, and of files and folders — moving a file
 rewrites the `include` paths that name it), document and workspace symbols, call
 and type hierarchy, signature help, code actions, folding and selection ranges,
 document links, and semantic tokens, alongside formatting (whole-document and
-range) and diagnostics (push and pull).
+range) and diagnostics (push and pull). It checks your `Project.toml` and
+`Manifest.toml` themselves too, and navigates an open `Project.toml`'s
+dependency names.
 
 The **Fatou** extension for VS Code and Open VSX
 ([Marketplace](https://marketplace.visualstudio.com/items?itemName=jolars.fatou),

--- a/TODO.md
+++ b/TODO.md
@@ -420,6 +420,13 @@ tenet the linter is purely semantic over Julia.
     map. Live *diagnostics* for the buffer belong with stage 3, where the TOML
     file becomes a real document with a route of its own; a manifest buffer is
     likewise not read, since nothing consumes one without a resolve.
+  - **The other half of that line**: the buffer is authoritative only while a
+    buffer exists. `set_project_files` seeds create-or-return so a re-resolve
+    cannot clobber an open file, which is exactly why a re-resolve does not
+    refresh a *closed* one either — the watched-file sync does, reverting an
+    environment file with no open document just as it does a `.jl` source
+    (`a_watched_project_file_change_clears_unresolved_import`). Without it a
+    `pkg> add` from a terminal never reaches the lint.
   - The guard was written first, the mirror of the body-edit firewall: a
     `Project.toml` edit must reach the declared deps and re-parse no Julia,
     while an edit leaving `[deps]` alone backdates.

--- a/TODO.md
+++ b/TODO.md
@@ -499,6 +499,15 @@ tenet the linter is purely semantic over Julia.
     why the other three needed no client change). A Julia document answers an
     empty list, not `null`: inlay *type* hints would need inference, which is
     out by tenet, but "this file has no hints" is the honest answer.
+  - **And a refresh nudge**, which the feature does not work without: the
+    versions come from the harvest, which lands seconds after `initialize`,
+    while a client re-requests hints only on an edit or a scroll. A full
+    harvest therefore sends `workspace/inlayHint/refresh`, capability-gated the
+    way `workspace/diagnostic/refresh` is, and its own signal rather than a
+    share of `DiagnosticsRefresh` — that one also fires per project-file
+    keystroke, and the spec has this request force a *global* recalculation.
+    Document links have the same staleness and no cure: the spec defines no
+    refresh request for them.
   - Deliberately not hinted: `[compat]`. A declared-range-versus-resolved hint
     there is interesting but overlaps `missing-compat`/`unknown-compat`, and it
     is a second rendering path deserving its own decision.

--- a/TODO.md
+++ b/TODO.md
@@ -349,7 +349,7 @@ flavors, and `is_environment_file` escalates a watched change to
 Since stage 2 a project file is also a salsa input, so its `[deps]` follow the
 editor's unsaved buffer; since stage 3 an open one is a document with a route of
 its own, and since stage 4a a `Project.toml` answers go-to-definition, hover,
-and document links on a dependency name.
+document links, and inlay hints on a dependency name.
 
 The target is what rust-analyzer gives `Cargo.toml`, which is narrower than it
 is usually remembered as: watch-and-reload, plus a document-selector entry so
@@ -459,10 +459,11 @@ tenet the linter is purely semantic over Julia.
     "toml"`, which exists only with a TOML extension installed), including
     `**/Manifest-v*.toml` to match `is_manifest_file` and the watcher globs.
 
-- [x] **Stage 4a: navigation.** Go-to-definition, hover, and document links on
-  a dependency name, in `src/lsp/project_navigation.rs`. `project_files.rs`
-  grew `dep_entries`/`dep_at`, the same spanned schema read the other way
-  round: not what is wrong with the file but what it names, and where.
+- [x] **Stage 4a: navigation.** Go-to-definition, hover, document links, and
+  inlay hints on a dependency name, in `src/lsp/project_navigation.rs`.
+  `project_files.rs` grew `dep_entries`/`dep_at`, the same spanned schema read
+  the other way round: not what is wrong with the file but what it names, and
+  where.
   - **The door.** `GlobalState::project_text` is the sibling of `julia_text`
     and the only other way into the read pool; every other handler still
     answers `null` for an environment file. A `Manifest.toml` answers nothing
@@ -480,6 +481,20 @@ tenet the linter is purely semantic over Julia.
     keyed by what the *manifest pinned*, not by what the harvest indexed — a
     package whose source was never found has an entry in one and not the other,
     and "installed, 0.4.5, source not found" is what a reader wants told.
+  - **Inlay hints** show each dependency's resolved version after its UUID.
+    Not a duplicate of hover, which is the on-demand one-at-a-time answer: the
+    `[deps]` table is almost entirely UUID, and the version lives in the
+    `Manifest.toml` next door, which nobody opens. Version only — the kind
+    belongs to "tell me about *this* dependency", and repeating "Registered
+    package" down the table is noise. This is fatou's **first** inlay hint
+    feature, so it took the capability, and a `provideInlayHints` entry in the
+    extension's `languageFeatures` gate (which is keyed by request kind, and is
+    why the other three needed no client change). A Julia document answers an
+    empty list, not `null`: inlay *type* hints would need inference, which is
+    out by tenet, but "this file has no hints" is the honest answer.
+  - Deliberately not hinted: `[compat]`. A declared-range-versus-resolved hint
+    there is interesting but overlaps `missing-compat`/`unknown-compat`, and it
+    is a second rendering path deserving its own decision.
   - Landed alongside: `site_locations` now normalizes, which fixes the Julia
     jump into a `dev`'d package too. Such a package's root is the manifest's
     `path` joined to the project directory, so it keeps that entry's `../`

--- a/TODO.md
+++ b/TODO.md
@@ -345,9 +345,10 @@ Rejected after probing (do not revisit without new evidence):
 `Project.toml`/`Manifest.toml` steer resolution (`environment::resolve` walks
 them the way Julia's loader does, `register_file_watchers` covers all five
 flavors, and `is_environment_file` escalates a watched change to
-`HarvestSignal::Environment`) and, since stage 1, report their own problems. The
-LSP document selector is still `.jl`-only, so they carry diagnostics but answer
-no requests.
+`HarvestSignal::Environment`) and, since stage 1, report their own problems.
+Since stage 2 a project file is also a salsa input, so its `[deps]` follow the
+editor's unsaved buffer. The LSP document selector is still `.jl`-only, so they
+carry diagnostics but answer no requests.
 
 The target is what rust-analyzer gives `Cargo.toml`, which is narrower than it
 is usually remembered as: watch-and-reload, plus a document-selector entry so
@@ -402,27 +403,45 @@ tenet the linter is purely semantic over Julia.
     reachable, and `dev_package` split so `entry_file` names the entry file a
     package *would* have.
 
-- [ ] **Stage 2: decide buffer versus disk. Design before code.** The project
-  file is a *push* input today: the harvester thread reads disk and calls
-  `set_declared_deps` at HIGH durability (`src/incremental.rs`). The moment an
-  editor holds an unsaved `Project.toml`, reading the disk copy is a bug. Doing
-  it properly makes the project file a salsa input keyed by path, with
-  `declared_deps` *derived* from it rather than pushed, which drops the
-  workspace project file off HIGH durability.
-  - The prize is the thing that makes the feature feel integrated: edit
-    `[deps]`, and `unresolved-import` updates across every `.jl` file in the
-    package without a save.
-  - The guard to write first is the mirror of `tests/salsa_incremental.rs`: a
-    `Project.toml` edit must invalidate the resolution layer and *not* the
-    parses. Without it this trades a body-edit firewall for a project-edit
-    stampede.
+- [x] **Stage 2: buffer for `[deps]`, disk for everything else.** The project
+  file was a *push* input: the harvester read disk and called
+  `set_declared_deps` at HIGH durability. It is now an ordinary `SourceFile`
+  keyed by path, with `project_declared_deps` deriving `[deps]` from its text —
+  so only the name → input mapping (`ProjectFiles`) stays HIGH durability, and
+  the file itself sits where every editable buffer sits.
+  - The prize landed: edit `[deps]` with no save, and `unresolved-import`
+    updates across the package (`an_unsaved_project_file_edit_clears_unresolved_import`).
+  - **The line drawn.** The buffer is authoritative for `[deps]` alone.
+    Everything that needs a resolved `Environment` — all six semantic project
+    file checks, `toml-syntax`, the library itself — stays on the harvester's
+    save/watch cadence and reads disk, because `environment::resolve` is
+    disk-coupled throughout and runs on a thread with no view of the document
+    map. Live *diagnostics* for the buffer belong with stage 3, where the TOML
+    file becomes a real document with a route of its own; a manifest buffer is
+    likewise not read, since nothing consumes one without a resolve.
+  - The guard was written first, the mirror of the body-edit firewall: a
+    `Project.toml` edit must reach the declared deps and re-parse no Julia,
+    while an edit leaving `[deps]` alone backdates.
+  - `ProjectFile::declared_dep_names` became the one definition of "declared",
+    shared with the CLI's `HarvestedLibrary::declared_deps`, so a name whose
+    UUID does not parse is declared for both. Landed alongside: a refresh nudge
+    now re-analyzes a *push* client's open documents instead of being pull-only
+    — the same gap meant a re-harvest never refreshed `unresolved-import` for
+    such a client either.
 
-- [ ] **Stage 3: make it a real document.** `documents` holds a bare
-  `TextBuffer` with no kind discriminant and `send_analysis` funnels everything
-  into the Julia parse, so a `didOpen` on a TOML file today would parse it as
-  Julia and publish nonsense. Needs a kind tag at the `didOpen` boundary and a
-  second route. `handle_watched_files` already forks on `is_environment_file`,
-  which is where the seam belongs.
+- [ ] **Stage 3: make it a real document.** `documents` still holds a bare
+  `TextBuffer` with no kind discriminant; `send_analysis` forks on the file name
+  instead (env files never analyze, project files route to the db as text),
+  which is a seam, not a document kind. A request handler still has nothing to
+  dispatch on. Needs a kind tag at the `didOpen` boundary and a real second
+  route.
+  - The obvious first tenant is *live project-file diagnostics*, the half stage
+    2 deliberately left on disk: `syntax_findings` is text-only and could serve
+    the buffer directly, but the six semantic checks need a resolved
+    `Environment` and so stay with the harvester — meaning two producers writing
+    one file's `env_diags`, and clear-once bookkeeping that has to merge two
+    cadences. That is the design problem to settle, and it is why the split is
+    here rather than in stage 2.
   - Client side, extend the selector in `editors/code/src/extension.ts`. Use a
     **pattern-only** entry (`{ scheme: "file", pattern:
     "**/{Project,JuliaProject,Manifest,JuliaManifest}.toml" }`), not `language:

--- a/TODO.md
+++ b/TODO.md
@@ -429,24 +429,34 @@ tenet the linter is purely semantic over Julia.
     — the same gap meant a re-harvest never refreshed `unresolved-import` for
     such a client either.
 
-- [ ] **Stage 3: make it a real document.** `documents` still holds a bare
-  `TextBuffer` with no kind discriminant; `send_analysis` forks on the file name
-  instead (env files never analyze, project files route to the db as text),
-  which is a seam, not a document kind. A request handler still has nothing to
-  dispatch on. Needs a kind tag at the `didOpen` boundary and a real second
-  route.
-  - The obvious first tenant is *live project-file diagnostics*, the half stage
-    2 deliberately left on disk: `syntax_findings` is text-only and could serve
-    the buffer directly, but the six semantic checks need a resolved
-    `Environment` and so stay with the harvester — meaning two producers writing
-    one file's `env_diags`, and clear-once bookkeeping that has to merge two
-    cadences. That is the design problem to settle, and it is why the split is
-    here rather than in stage 2.
-  - Client side, extend the selector in `editors/code/src/extension.ts`. Use a
-    **pattern-only** entry (`{ scheme: "file", pattern:
-    "**/{Project,JuliaProject,Manifest,JuliaManifest}.toml" }`), not `language:
-    "toml"`: that language id exists only if the user happens to have a TOML
-    extension installed.
+- [x] **Stage 3: make it a real document.** `Document` now carries a
+  `DocumentKind` (`Julia`/`Project`/`Manifest`), tagged once at `didOpen`, and
+  `send_analysis`'s file-name fork became `route_document`: a real two-route
+  dispatch on the tag, with the TOML route re-deriving the file's own findings
+  from the buffer.
+  - **Live project-file diagnostics landed**, the half stage 2 left on disk:
+    `syntax_findings` serves the buffer at edit cadence, so a broken
+    `Project.toml` reports on the keystroke, with no save and no harvester (the
+    end-to-end test opens no workspace folder at all).
+  - **The two cadences.** The buffer's set (`buffer_diags`) **supersedes** the
+    harvester's (`env_diags`) rather than joining it: computed from different
+    texts, their union is a report of neither, and a buffer that does not parse
+    means the harvester's set — its own syntax verdict, or semantic findings
+    whose ranges index the disk text — describes a file the user has moved past.
+    A buffer that parses contributes nothing, which is what keeps the semantic
+    checks visible in an open file. Bookkeeping stayed simple as a result: a
+    publish goes out only when there is something to say or to take back, and
+    the live entry is dropped on close. The one accepted seam is that fixing a
+    syntax error without saving lets the disk verdict reappear until the save.
+  - **The gate the client selector newly needed**: with environment files in the
+    selector, every request can arrive for a `Project.toml`, so language
+    features go through `julia_text` and answer `null` for one — a format or a
+    hover would otherwise parse TOML as Julia. Pull diagnostics still report
+    nothing for these documents: both producers push, so answering the pull too
+    would double them up.
+  - Client side, the selector gained pattern-only entries (never `language:
+    "toml"`, which exists only with a TOML extension installed), including
+    `**/Manifest-v*.toml` to match `is_manifest_file` and the watcher globs.
 
 - [ ] **Stage 4: features**, in rough value-per-effort order.
   - Go-to-definition on a `[deps]` name, landing on the package's entry file.

--- a/TODO.md
+++ b/TODO.md
@@ -501,12 +501,32 @@ tenet the linter is purely semantic over Julia.
     spelling — the filesystem resolves it and a URI does not, and a client
     comparing URIs textually opens a second tab onto a file it already has.
 
+- [x] **Stage 4b, first half: document links on manifest `path` entries.** The
+  one feature a manifest answers, and the only thing in one that anchors
+  anywhere — `path` is the sole entry field naming something outside the file.
+  - **The spans, which were the cost.** A manifest is parsed against a plain
+    table (its 1.0 and 2.0 layouts differ) and a `toml::Value` carries none, so
+    `manifest_path_entries` adds a typed schema over the one field that needs
+    one. It is two parse attempts, as expected: one schema cannot cover both
+    layouts, since `serde(flatten)`/`untagged` buffer through serde's `Content`
+    and drop the span hook silently. 2.0 is tried first, and 1.0 only when it
+    comes up empty — a 2.0 manifest's `julia_version` is a string where the 1.0
+    schema wants an array of entries.
+  - **The target is the root's project file**, not the root: a `dev`'d root is a
+    package, what identifies a package is its `Project.toml`, and a client
+    cannot open a directory URI. A root with neither spelling is linked as-is —
+    that it is not a package is worth walking into, and the `path` may be a typo.
+  - **No library, no database.** The path resolves through `resolve_dev_path`,
+    the same join the harvest makes, so the link and the environment cannot
+    disagree about where the package is; `normalize_path` collapses the `../`
+    for the reason stage 4a's jump targets do. That makes it the one project-file
+    feature with no snapshot in its handler, and `manifest_text` the third and
+    narrowest door into the read pool.
+  - Landed alongside: `uri::anchor_dir`, one definition of "the directory a
+    relative path in this document resolves against", shared with the Julia
+    document's `include` links.
+
 - [ ] **Stage 4b: the rest**, deferred with stage 4a's route already in place.
-  - Document links on manifest `path` entries. The costly half of that bullet:
-    a manifest is deliberately parsed against a plain table (its 1.0 and 2.0
-    layouts differ), so it carries no spans, and typing it means two parse
-    attempts against two spanned schemas — `serde(flatten)`/`untagged` silently
-    drop the span hook.
   - Completion of dependency names, the expensive one. On a default depot the
     registry is a `General.tar.gz`, so the full version needs gzip and tar to
     reach `Registry.toml`. Scope the first pass to packages already installed in

--- a/TODO.md
+++ b/TODO.md
@@ -480,11 +480,11 @@ tenet the linter is purely semantic over Julia.
     keyed by what the *manifest pinned*, not by what the harvest indexed — a
     package whose source was never found has an entry in one and not the other,
     and "installed, 0.4.5, source not found" is what a reader wants told.
-  - Landed alongside: the entry target is `normalize_path`ed, since a `dev`'d
-    dependency's root keeps the manifest's `../` spelling. `definition.rs`'s
-    Julia jump into a `dev`'d package has the same seam and is *not* fixed —
-    `site_locations` does not normalize, and changing that is an unrelated
-    feature's behavior.
+  - Landed alongside: `site_locations` now normalizes, which fixes the Julia
+    jump into a `dev`'d package too. Such a package's root is the manifest's
+    `path` joined to the project directory, so it keeps that entry's `../`
+    spelling — the filesystem resolves it and a URI does not, and a client
+    comparing URIs textually opens a second tab onto a file it already has.
 
 - [ ] **Stage 4b: the rest**, deferred with stage 4a's route already in place.
   - Document links on manifest `path` entries. The costly half of that bullet:

--- a/TODO.md
+++ b/TODO.md
@@ -347,8 +347,9 @@ them the way Julia's loader does, `register_file_watchers` covers all five
 flavors, and `is_environment_file` escalates a watched change to
 `HarvestSignal::Environment`) and, since stage 1, report their own problems.
 Since stage 2 a project file is also a salsa input, so its `[deps]` follow the
-editor's unsaved buffer. The LSP document selector is still `.jl`-only, so they
-carry diagnostics but answer no requests.
+editor's unsaved buffer; since stage 3 an open one is a document with a route of
+its own, and since stage 4a a `Project.toml` answers go-to-definition, hover,
+and document links on a dependency name.
 
 The target is what rust-analyzer gives `Cargo.toml`, which is narrower than it
 is usually remembered as: watch-and-reload, plus a document-selector entry so
@@ -458,16 +459,45 @@ tenet the linter is purely semantic over Julia.
     "toml"`, which exists only with a TOML extension installed), including
     `**/Manifest-v*.toml` to match `is_manifest_file` and the watcher globs.
 
-- [ ] **Stage 4: features**, in rough value-per-effort order.
-  - Go-to-definition on a `[deps]` name, landing on the package's entry file.
-    Nearly free: `LibraryRoots` already maps package name to source root.
-  - Hover on a dep: version, kind (stdlib/registered/dev), and resolved path,
-    straight off `Package`.
-  - Document links on `[deps]` names and on manifest `path` entries.
+- [x] **Stage 4a: navigation.** Go-to-definition, hover, and document links on
+  a dependency name, in `src/lsp/project_navigation.rs`. `project_files.rs`
+  grew `dep_entries`/`dep_at`, the same spanned schema read the other way
+  round: not what is wrong with the file but what it names, and where.
+  - **The door.** `GlobalState::project_text` is the sibling of `julia_text`
+    and the only other way into the read pool; every other handler still
+    answers `null` for an environment file. A `Manifest.toml` answers nothing
+    at all, so the route is per-*kind*, not per-file-is-TOML.
+  - **No `compute_*`/`*_via_db` split**, unlike every Julia feature. Those
+    exist to serve a cached parse tree and fall back when the tracked input
+    lags the buffer; here the parse is a TOML parse of the buffer itself, so
+    there is nothing to be stale against. Only the `salsa::Cancelled` guard
+    remains.
+  - All three tables answer (`[deps]`, `[weakdeps]`, `[extras]`) — each names a
+    real package. `[compat]` does not: its keys may name `julia`.
+  - Hover needed the one piece of new plumbing: `Package` lived only on the
+    harvester thread, so `LibraryDeps` carries version and kind into the
+    database. It is set apart from `set_library`'s three maps because it is
+    keyed by what the *manifest pinned*, not by what the harvest indexed — a
+    package whose source was never found has an entry in one and not the other,
+    and "installed, 0.4.5, source not found" is what a reader wants told.
+  - Landed alongside: the entry target is `normalize_path`ed, since a `dev`'d
+    dependency's root keeps the manifest's `../` spelling. `definition.rs`'s
+    Julia jump into a `dev`'d package has the same seam and is *not* fixed —
+    `site_locations` does not normalize, and changing that is an unrelated
+    feature's behavior.
+
+- [ ] **Stage 4b: the rest**, deferred with stage 4a's route already in place.
+  - Document links on manifest `path` entries. The costly half of that bullet:
+    a manifest is deliberately parsed against a plain table (its 1.0 and 2.0
+    layouts differ), so it carries no spans, and typing it means two parse
+    attempts against two spanned schemas — `serde(flatten)`/`untagged` silently
+    drop the span hook.
   - Completion of dependency names, the expensive one. On a default depot the
     registry is a `General.tar.gz`, so the full version needs gzip and tar to
     reach `Registry.toml`. Scope the first pass to packages already installed in
-    the depot: no new dependency, no network.
+    the depot: no new dependency, no network. Note that *nothing* enumerates
+    `<depot>/packages` today — it is only ever probed by exact slug — so even
+    the cheap pass is new code.
   - `name`/`uuid` upkeep on a rename, the edit half of the `willRenameFiles`
     entry above.
 

--- a/TODO.md
+++ b/TODO.md
@@ -464,7 +464,13 @@ tenet the linter is purely semantic over Julia.
     would double them up.
   - Client side, the selector gained pattern-only entries (never `language:
     "toml"`, which exists only with a TOML extension installed), including
-    `**/Manifest-v*.toml` to match `is_manifest_file` and the watcher globs.
+    `**/Manifest-v[0-9]*.toml` — the digit is `is_manifest_file`, which wants a
+    version it can parse, where the watcher glob can afford to be looser.
+  - **A `.toml` is never Julia**, which is what keeps that gap from mattering:
+    the recognized flavors get their routes and every other `.toml` is
+    `DocumentKind::Other`, answering nothing. Written that way round rather
+    than carving the flavors out of a Julia default, so the server's behavior
+    stops depending on how wide a client's selector happens to be.
 
 - [x] **Stage 4a: navigation.** Go-to-definition, hover, document links, and
   inlay hints on a dependency name, in `src/lsp/project_navigation.rs`.

--- a/docs/src/guide/comparison.md
+++ b/docs/src/guide/comparison.md
@@ -62,7 +62,9 @@ A language server made by the author of
 type inference through JET.jl, macro-aware navigation through
 [JuliaLowering.jl](https://github.com/c42f/JuliaLowering.jl). It offers what the
 others cannot, including types on hover, inlay type hints, and diagnostics for
-non-existent field access or out-of-bounds indexing.
+non-existent field access or out-of-bounds indexing. Inferred types are the
+dividing line: Fatou does show inlay hints, but only for facts it can read off
+disk, such as a dependency's resolved version in a `Project.toml`.
 
 It is also the furthest from Fatou. As of 2026 its README calls it experimental
 and not production-ready, it needs Julia 1.12 or newer, and it is under heavy

--- a/docs/src/guide/editors.md
+++ b/docs/src/guide/editors.md
@@ -7,8 +7,9 @@ definition, references, rename (of symbols, and of files and folders — moving 
 file rewrites the `include` paths that name it), document and workspace symbols,
 call and type hierarchy, folding ranges, document links, selection ranges, and
 semantic tokens. It also checks your `Project.toml` and `Manifest.toml`
-themselves, and navigates an open `Project.toml`'s dependency names, with inlay
-hints for their resolved versions.
+themselves, navigates an open `Project.toml`'s dependency names with inlay hints
+for their resolved versions, and links an open `Manifest.toml`'s `path` entries
+to the packages they pin.
 
 ## Prerequisites
 
@@ -204,8 +205,10 @@ An open `Project.toml` also answers on its dependency names: go-to-definition
 and a document link take you to the package's entry file, hovering reports the
 version, kind, and resolved path the environment gave it, and an inlay hint puts
 each resolved version beside its UUID, so you can read off what you are actually
-on without opening the `Manifest.toml`. Everything else stays off for these
-files — formatting a `Project.toml` would mean parsing TOML as Julia.
+on without opening the `Manifest.toml`. In an open `Manifest.toml`, each `path`
+entry — a package you have `dev`'d — is a link to that package's `Project.toml`.
+Everything else stays off for these files — formatting a `Project.toml` would
+mean parsing TOML as Julia.
 
 ## Configuration
 

--- a/docs/src/guide/editors.md
+++ b/docs/src/guide/editors.md
@@ -193,6 +193,13 @@ arguments for `*.jl` files, rooted at `Project.toml`, `JuliaProject.toml`, or
 `.git`. Nothing else is required, because Fatou discovers its own configuration
 from the file's directory upward.
 
+Fatou also checks your `Project.toml` and `Manifest.toml` themselves, and
+publishes those findings on the file at fault whether or not it is open. If you
+additionally attach the server to those files (the VS Code extension does), an
+open one reports its TOML errors as you type, before you save; language
+features such as hover and formatting stay off for them, since they are not
+Julia.
+
 ## Configuration
 
 Fatou reads its settings from a `fatou.toml` next to your project (see the

--- a/docs/src/guide/editors.md
+++ b/docs/src/guide/editors.md
@@ -6,7 +6,8 @@ parse diagnostics with quick fixes, completion, hover, signature help, go-to
 definition, references, rename (of symbols, and of files and folders — moving a
 file rewrites the `include` paths that name it), document and workspace symbols,
 call and type hierarchy, folding ranges, document links, selection ranges, and
-semantic tokens.
+semantic tokens. It also checks your `Project.toml` and `Manifest.toml`
+themselves, and navigates an open `Project.toml`'s dependency names.
 
 ## Prerequisites
 
@@ -196,9 +197,13 @@ from the file's directory upward.
 Fatou also checks your `Project.toml` and `Manifest.toml` themselves, and
 publishes those findings on the file at fault whether or not it is open. If you
 additionally attach the server to those files (the VS Code extension does), an
-open one reports its TOML errors as you type, before you save; language
-features such as hover and formatting stay off for them, since they are not
-Julia.
+open one reports its TOML errors as you type, before you save.
+
+An open `Project.toml` also answers on its dependency names: go-to-definition
+and a document link take you to the package's entry file, and hovering reports
+the version, kind, and resolved path the environment gave it. Everything else
+stays off for these files — formatting a `Project.toml` would mean parsing TOML
+as Julia.
 
 ## Configuration
 

--- a/docs/src/guide/editors.md
+++ b/docs/src/guide/editors.md
@@ -7,7 +7,8 @@ definition, references, rename (of symbols, and of files and folders — moving 
 file rewrites the `include` paths that name it), document and workspace symbols,
 call and type hierarchy, folding ranges, document links, selection ranges, and
 semantic tokens. It also checks your `Project.toml` and `Manifest.toml`
-themselves, and navigates an open `Project.toml`'s dependency names.
+themselves, and navigates an open `Project.toml`'s dependency names, with inlay
+hints for their resolved versions.
 
 ## Prerequisites
 
@@ -200,10 +201,11 @@ additionally attach the server to those files (the VS Code extension does), an
 open one reports its TOML errors as you type, before you save.
 
 An open `Project.toml` also answers on its dependency names: go-to-definition
-and a document link take you to the package's entry file, and hovering reports
-the version, kind, and resolved path the environment gave it. Everything else
-stays off for these files — formatting a `Project.toml` would mean parsing TOML
-as Julia.
+and a document link take you to the package's entry file, hovering reports the
+version, kind, and resolved path the environment gave it, and an inlay hint puts
+each resolved version beside its UUID, so you can read off what you are actually
+on without opening the `Manifest.toml`. Everything else stays off for these
+files — formatting a `Project.toml` would mean parsing TOML as Julia.
 
 ## Configuration
 

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -287,6 +287,16 @@ async function startClient(
       { scheme: "file", language: "julia" },
       { scheme: "untitled", language: "julia" },
       { scheme: "file", pattern: "**/*.jl" },
+      // Julia's environment files, so an open one gets its own diagnostics.
+      // Matched by pattern alone, never by `language: "toml"`: that language
+      // id exists only if the user happens to have a TOML extension
+      // installed. The version-specific manifests match the server's
+      // `is_manifest_file` and its watcher globs.
+      {
+        scheme: "file",
+        pattern: "**/{Project,JuliaProject,Manifest,JuliaManifest}.toml",
+      },
+      { scheme: "file", pattern: "**/Manifest-v*.toml" },
     ],
     outputChannel,
     traceOutputChannel: outputChannel,

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -293,12 +293,13 @@ async function startClient(
       // Matched by pattern alone, never by `language: "toml"`: that language
       // id exists only if the user happens to have a TOML extension
       // installed. The version-specific manifests match the server's
-      // `is_manifest_file` and its watcher globs.
+      // `is_manifest_file`, which wants a version it can parse — hence the
+      // digit, where the watcher glob can afford to be looser.
       {
         scheme: "file",
         pattern: "**/{Project,JuliaProject,Manifest,JuliaManifest}.toml",
       },
-      { scheme: "file", pattern: "**/Manifest-v*.toml" },
+      { scheme: "file", pattern: "**/Manifest-v[0-9]*.toml" },
     ],
     outputChannel,
     traceOutputChannel: outputChannel,

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -251,6 +251,8 @@ function buildMiddleware(): Middleware {
       lf(() => next(document, positions, token)),
     provideDocumentLinks: (document, token, next) =>
       lf(() => next(document, token)),
+    provideInlayHints: (document, viewPort, token, next) =>
+      lf(() => next(document, viewPort, token)),
   };
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -392,7 +392,7 @@ fn walk_up_for_project(anchor: &Path) -> Option<PathBuf> {
 }
 
 /// The project file within `dir`, honoring `JuliaProject.toml` precedence.
-fn project_file_in(dir: &Path) -> Option<PathBuf> {
+pub(crate) fn project_file_in(dir: &Path) -> Option<PathBuf> {
     PROJECT_NAMES
         .iter()
         .map(|name| dir.join(name))
@@ -840,6 +840,59 @@ fn parse_entry(
     })
 }
 
+// --- The manifest, with spans ----------------------------------------------
+
+/// Each package name's entries, of which only `path` is typed: it is the one
+/// field naming something outside the manifest, and so the only one a reader
+/// can be sent to.
+type SpannedEntries = BTreeMap<String, Vec<SpannedEntry>>;
+
+/// A manifest read for its `path` entries alone, *with spans* — format 2.0,
+/// which nests every entry under a top-level `deps` table.
+///
+/// [`parse_manifest`] reads a plain [`toml::Table`] on purpose, and a
+/// `toml::Value` carries no span; a consumer that anchors inside a manifest
+/// therefore needs a typed schema. One schema cannot cover both layouts:
+/// `serde(flatten)` and `untagged` buffer through serde's `Content`, which
+/// drops the deserializer's span hook silently. Hence two attempts, one per
+/// layout (see [`manifest_path_entries`]).
+#[derive(serde::Deserialize)]
+struct SpannedManifest {
+    #[serde(default)]
+    deps: SpannedEntries,
+}
+
+#[derive(serde::Deserialize)]
+struct SpannedEntry {
+    path: Option<Spanned<String>>,
+}
+
+/// Every `path = "..."` a manifest's text pins, as the package name and the
+/// spanned path, in name order. Spans are byte offsets into `text`, exactly as
+/// [`ProjectFile`]'s are.
+///
+/// Empty when the text parses against neither layout: a half-typed manifest
+/// must anchor nothing, and its own `toml-syntax` finding reports the state it
+/// is in.
+pub(crate) fn manifest_path_entries(text: &str) -> Vec<(String, Spanned<String>)> {
+    let deps = toml::from_str::<SpannedManifest>(text)
+        .ok()
+        .map(|manifest| manifest.deps)
+        .filter(|deps| !deps.is_empty())
+        // Format 1.0 puts each package's array at the top level instead. Tried
+        // only once 2.0 has come up empty, since a 2.0 manifest's
+        // `julia_version` is a string where this schema wants an array.
+        .or_else(|| toml::from_str::<SpannedEntries>(text).ok())
+        .unwrap_or_default();
+    deps.into_iter()
+        .flat_map(|(name, entries)| {
+            entries
+                .into_iter()
+                .filter_map(move |entry| Some((name.clone(), entry.path?)))
+        })
+        .collect()
+}
+
 /// A package's `deps` may be an array of names or a table (name -> uuid).
 fn extract_deps(value: Option<&toml::Value>) -> Vec<String> {
     match value {
@@ -853,7 +906,13 @@ fn extract_deps(value: Option<&toml::Value>) -> Vec<String> {
 }
 
 /// Resolve a `dev`'d package's root relative to the project directory.
-fn resolve_dev_path(project_dir: &Path, path: &str) -> PathBuf {
+///
+/// Shared with the manifest's document links ([`crate::lsp`]), which point at
+/// the root this computes: a link that resolved `path` its own way would send a
+/// reader somewhere the environment never looked. The manifest sits beside the
+/// project file, so a caller holding only the manifest's directory holds the
+/// project directory too.
+pub(crate) fn resolve_dev_path(project_dir: &Path, path: &str) -> PathBuf {
     let path = Path::new(path);
     if path.is_absolute() {
         path.to_path_buf()

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -13,7 +13,7 @@
 //! This module is intentionally standalone: it is not yet wired into the salsa
 //! layer, the LSP, or the CLI. Later Phase 3/5 work consumes [`Environment`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -133,6 +133,12 @@ pub struct Environment {
     pub name: Option<String>,
     pub uuid: Option<Uuid>,
     pub direct_deps: BTreeMap<String, Uuid>,
+    /// The names in `[deps]`, unfiltered — see
+    /// [`ProjectFile::declared_dep_names`]. Kept beside
+    /// [`direct_deps`](Self::direct_deps), which drops any entry whose UUID does
+    /// not parse, so that "what this package may `using`" has one answer no
+    /// matter which consumer asks.
+    pub declared_deps: BTreeSet<String>,
     pub packages: Vec<Package>,
     pub depots: Vec<PathBuf>,
     pub source: EnvSource,
@@ -291,7 +297,7 @@ pub fn resolve(ctx: &EnvContext) -> Result<Option<Environment>, EnvironmentError
         .map(Path::to_path_buf)
         .unwrap_or_default();
 
-    let (name, uuid, direct_deps) = parse_project(&project_file)?;
+    let meta = parse_project(&project_file)?;
     let manifest_file = find_manifest(&project_dir);
     let mut packages = match &manifest_file {
         Some(path) => parse_manifest(path, &project_dir, &depots)?,
@@ -307,9 +313,10 @@ pub fn resolve(ctx: &EnvContext) -> Result<Option<Environment>, EnvironmentError
         project_file,
         project_dir,
         manifest_file,
-        name,
-        uuid,
-        direct_deps,
+        name: meta.name,
+        uuid: meta.uuid,
+        direct_deps: meta.direct_deps,
+        declared_deps: meta.declared_deps,
         packages,
         depots,
         source,
@@ -657,16 +664,35 @@ impl ProjectFile {
     /// Drop the spans, yielding what [`resolve`] stores on [`Environment`]. A
     /// `uuid` that does not parse is dropped rather than raised.
     fn into_meta(self) -> ProjectMeta {
+        let declared_deps = self.declared_dep_names();
         let direct_deps = self
             .deps
             .into_iter()
             .filter_map(|(name, uuid)| Some((name.into_inner(), uuid.into_inner().parse().ok()?)))
             .collect();
-        (
-            self.name.map(Spanned::into_inner),
-            self.uuid.and_then(|uuid| uuid.into_inner().parse().ok()),
+        ProjectMeta {
+            name: self.name.map(Spanned::into_inner),
+            uuid: self.uuid.and_then(|uuid| uuid.into_inner().parse().ok()),
             direct_deps,
-        )
+            declared_deps,
+        }
+    }
+
+    /// The names in `[deps]`: what this project's own sources may `using` or
+    /// `import`. Deliberately *not* filtered by whether the paired UUID parses,
+    /// unlike [`ProjectMeta::direct_deps`] — a malformed UUID is a defect in the
+    /// file, not an un-declaration, and `unresolved-import` asks only whether
+    /// the name was declared.
+    ///
+    /// The one definition of "declared", shared by the CLI (through
+    /// [`Environment::declared_deps`], which
+    /// [`HarvestedLibrary`](crate::index::HarvestedLibrary) carries) and the
+    /// language server (through
+    /// [`project_declared_deps`](crate::incremental::project_declared_deps),
+    /// which reads an editor's unsaved buffer). The two must not drift: they
+    /// answer the same lint.
+    pub(crate) fn declared_dep_names(&self) -> BTreeSet<String> {
+        self.deps.keys().map(|name| name.as_ref().clone()).collect()
     }
 
     /// The `[compat].julia` range, if present and parseable.
@@ -675,7 +701,13 @@ impl ProjectFile {
     }
 }
 
-type ProjectMeta = (Option<String>, Option<Uuid>, BTreeMap<String, Uuid>);
+/// A project file's contents with the spans dropped, as [`resolve`] stores them.
+struct ProjectMeta {
+    name: Option<String>,
+    uuid: Option<Uuid>,
+    direct_deps: BTreeMap<String, Uuid>,
+    declared_deps: BTreeSet<String>,
+}
 
 fn parse_project(path: &Path) -> Result<ProjectMeta, EnvironmentError> {
     Ok(parse_project_text(path, &read_text(path)?)?.into_meta())
@@ -1091,6 +1123,25 @@ projects = ["sub"]
             project.julia_compat().map(|range| range.min),
             Some(crate::julia_version::Version::new(1, 10, 0)),
             "the keys fatou does know survive alongside the ones it does not"
+        );
+    }
+
+    /// A dependency whose UUID does not parse is still *declared*: the name is
+    /// what `unresolved-import` asks about, so it must survive the filter that
+    /// `direct_deps` applies.
+    #[test]
+    fn a_malformed_uuid_does_not_undeclare_its_dependency() {
+        let text =
+            "[deps]\nDates = \"ade2ca70-3891-5945-98fb-dc099432e06a\"\nBroken = \"not-a-uuid\"\n";
+        let project = parse_project_text(Path::new("Project.toml"), text).unwrap();
+        assert_eq!(
+            project.declared_dep_names(),
+            BTreeSet::from(["Dates".to_string(), "Broken".to_string()])
+        );
+        let meta = project.into_meta();
+        assert!(
+            !meta.direct_deps.contains_key("Broken"),
+            "the UUID-keyed map still drops it"
         );
     }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -100,6 +100,30 @@ pub struct Package {
     pub source: Option<PathBuf>,
 }
 
+impl Package {
+    /// The facts about this package that survive the harvest: what a consumer
+    /// with no [`Environment`] in hand — the language server, whose database
+    /// holds the harvest and not the resolve — can still report about it.
+    ///
+    /// [`source`](Package::source) is deliberately absent: the harvest already
+    /// records the root of every package it indexed, and a package it did not
+    /// index has nothing to point at.
+    pub fn meta(&self) -> PackageMeta {
+        PackageMeta {
+            version: self.version.clone(),
+            kind: self.kind,
+        }
+    }
+}
+
+/// A pinned package's version and kind, keyed by name away from the
+/// [`Environment`] it was resolved from. See [`Package::meta`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageMeta {
+    pub version: Option<String>,
+    pub kind: PackageKind,
+}
+
 /// Which discovery strategy located the environment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EnvSource {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -719,6 +719,14 @@ pub(crate) fn parse_project_text(path: &Path, text: &str) -> Result<ProjectFile,
     parse_toml(path, text)
 }
 
+/// [`parse_project_text`] for a caller with no file name to name: a consumer
+/// that discards the failure rather than reporting it. Kept apart so such a
+/// caller does not have to invent a placeholder path that the error would then
+/// carry.
+pub(crate) fn parse_project_str(text: &str) -> Option<ProjectFile> {
+    toml::from_str(text).ok()
+}
+
 // --- Manifest.toml ---------------------------------------------------------
 
 fn parse_manifest(

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -68,22 +68,23 @@ pub struct LibraryPackages(pub BTreeMap<String, Arc<PackageIndex>>);
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LibraryRoots(pub BTreeMap<String, PathBuf>);
 
-/// Each workspace package's declared direct dependencies (its project's
-/// `Project.toml` `[deps]`), keyed by package name — see
-/// [`HarvestedLibrary::declared_deps`](crate::index::HarvestedLibrary::declared_deps).
-/// Its own salsa input rather than a [`LibraryIndex`] field: it comes from the
-/// project files, not the harvest, and changes on a `Project.toml` edit rather
-/// than a re-harvest.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct LibraryDeclaredDeps(pub BTreeMap<String, Arc<DeclaredDeps>>);
-
-/// The workspace packages' declared dependency sets, as a HIGH-durability
-/// singleton input (see [`LibraryDeclaredDeps`]). Absent until the environment
-/// resolves, which leaves `unresolved-import` silent.
+/// Each workspace package's project file, keyed by package name, as the
+/// ordinary [`SourceFile`] input holding its text. Its own input rather than a
+/// [`LibraryIndex`] field: it comes from the project files, not the harvest, so
+/// a `Project.toml` edit moves it without a re-harvest and a re-harvest leaves
+/// it alone. Absent until the environment resolves, which leaves
+/// `unresolved-import` silent.
+///
+/// HIGH durability covers the *mapping* only — which file belongs to which
+/// package changes on a re-resolve. The file's text stays a LOW-durability
+/// `SourceFile` an editor may rewrite per keystroke, and
+/// [`project_declared_deps`] derives the dependency set from it. That split is
+/// the whole point: `[deps]` follows the unsaved buffer, while a project-file
+/// edit invalidates no `.jl` parse (`tests/salsa_incremental.rs`).
 #[salsa::input(singleton)]
-pub struct ProjectDeps {
+pub struct ProjectFiles {
     #[returns(ref)]
-    pub declared: LibraryDeclaredDeps,
+    pub files: BTreeMap<String, SourceFile>,
 }
 
 /// The whole harvested library, as a single HIGH-durability salsa input. One
@@ -333,6 +334,34 @@ pub fn include_edges(db: &dyn IncrementalDb, file: SourceFile) -> Vec<IncludeEdg
     let root = parsed_tree_root(db, file);
     let base_dir = file.path(db).as_deref().and_then(Path::parent);
     project::include_edges(&root, base_dir)
+}
+
+/// The names in `file`'s `[deps]`, when it parses as a project file — the
+/// derived replacement for a dependency map pushed in on each re-harvest. Read
+/// through [`IncrementalDatabase::declared_deps`], which maps a package name to
+/// its project file via [`ProjectFiles`].
+///
+/// `None` for a file that does not parse. A half-typed `[deps]` table must make
+/// `unresolved-import` go *quiet* rather than report a name as undeclared: the
+/// same failure direction the lint's cold path already takes (`crate::lsp::lint`).
+///
+/// This is the firewall in the project file's direction. An edit anywhere else
+/// in the file — `[compat]`, `version`, a comment — returns an equal set and
+/// backdates, so no consumer re-runs; `tests/salsa_incremental.rs` pins both
+/// that and the converse, that this never reaches a `.jl` parse.
+#[salsa::tracked(returns(clone))]
+pub fn project_declared_deps(
+    db: &dyn IncrementalDb,
+    file: SourceFile,
+) -> Option<Arc<DeclaredDeps>> {
+    // The path is carried only for the error this discards; an in-memory
+    // project file (no path) parses just the same.
+    let path = file
+        .path(db)
+        .as_deref()
+        .unwrap_or_else(|| Path::new("Project.toml"));
+    let project = crate::environment::parse_project_text(path, file.text(db)).ok()?;
+    Some(Arc::new(project.declared_dep_names()))
 }
 
 /// One unresolvable static `include("literal")` site: the decoded `path` written
@@ -1072,21 +1101,34 @@ impl IncrementalDatabase {
         self.set_library(packages, roots, workspaces);
     }
 
-    /// Replace the workspace packages' declared dependency sets, at HIGH
-    /// durability. Kept apart from [`set_library`](Self::set_library) because it
-    /// tracks the project files rather than the harvest: a `Project.toml` edit
-    /// changes it without a re-harvest, and a re-harvest leaves it alone.
-    pub fn set_declared_deps(&mut self, declared: BTreeMap<String, Arc<DeclaredDeps>>) {
-        let declared = LibraryDeclaredDeps(declared);
-        match ProjectDeps::try_get(self) {
+    /// Track each workspace package's project file and record the name → input
+    /// mapping at HIGH durability. Kept apart from
+    /// [`set_library`](Self::set_library) because it tracks the project files
+    /// rather than the harvest: a `Project.toml` edit changes what
+    /// [`declared_deps`](Self::declared_deps) answers without a re-harvest, and
+    /// a re-harvest leaves the text alone.
+    ///
+    /// Seeding goes through [`seed_disk_file`](Self::seed_disk_file), which is
+    /// create-or-return: a re-resolve must never clobber an open, unsaved
+    /// `Project.toml` buffer with the disk copy. A path that is neither tracked
+    /// nor readable contributes no entry, exactly as an unresolved environment
+    /// contributes none.
+    pub fn set_project_files(&mut self, paths: BTreeMap<String, PathBuf>) {
+        let mut files: BTreeMap<String, SourceFile> = BTreeMap::new();
+        for (name, path) in paths {
+            if let Some(file) = self.seed_disk_file(&path) {
+                files.insert(name, file);
+            }
+        }
+        match ProjectFiles::try_get(self) {
             Some(input) => {
                 input
-                    .set_declared(self)
+                    .set_files(self)
                     .with_durability(Durability::HIGH)
-                    .to(declared);
+                    .to(files);
             }
             None => {
-                let _ = ProjectDeps::builder(declared)
+                let _ = ProjectFiles::builder(files)
                     .durability(Durability::HIGH)
                     .new(self);
             }
@@ -1095,12 +1137,23 @@ impl IncrementalDatabase {
 
     /// The declared direct dependencies of the workspace package `name`, when
     /// the environment has resolved and that package is one under development.
+    /// Derived from the project file's tracked text (see
+    /// [`project_declared_deps`]), so an editor's unsaved `[deps]` edit counts.
     pub fn declared_deps(&self, name: &str) -> Option<Arc<DeclaredDeps>> {
-        ProjectDeps::try_get(self)?
-            .declared(self)
-            .0
-            .get(name)
-            .cloned()
+        project_declared_deps(self, self.project_file_of(name)?)
+    }
+
+    /// The declared dependencies read off the project file tracked at `path`,
+    /// for a caller holding a path rather than a package name — the language
+    /// server's gate for whether a project-file keystroke changed anything a
+    /// consumer would notice. `None` for an untracked or unparseable file.
+    pub fn declared_deps_of_file(&self, path: &Path) -> Option<Arc<DeclaredDeps>> {
+        project_declared_deps(self, self.lookup_file(path)?)
+    }
+
+    /// The input tracking package `name`'s project file, if one is registered.
+    fn project_file_of(&self, name: &str) -> Option<SourceFile> {
+        ProjectFiles::try_get(self)?.files(self).get(name).copied()
     }
 
     /// Insert or replace a single package's index, keeping the rest (and the

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use salsa::{Durability, Setter};
 
+use crate::environment::PackageMeta;
 use crate::index::{DeclaredDeps, PackageIndex};
 use crate::parser::{Edit, ParseDiagnostic, ReparseTier, diff_edit, parse, reparse, reparse_edits};
 use crate::project::{self, IncludeEdge};
@@ -68,6 +69,13 @@ pub struct LibraryPackages(pub BTreeMap<String, Arc<PackageIndex>>);
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LibraryRoots(pub BTreeMap<String, PathBuf>);
 
+/// Every manifest-pinned package's version and kind, keyed by name — what a
+/// hover over a `[deps]` entry reports. Wrapped for the same reason as
+/// [`LibraryPackages`], and keyed differently from [`LibraryRoots`] on purpose:
+/// see [`HarvestedLibrary::deps`](crate::index::HarvestedLibrary::deps).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LibraryDeps(pub BTreeMap<String, PackageMeta>);
+
 /// Each workspace package's project file, keyed by package name, as the
 /// ordinary [`SourceFile`] input holding its text. Its own input rather than a
 /// [`LibraryIndex`] field: it comes from the project files, not the harvest, so
@@ -107,6 +115,11 @@ pub struct LibraryIndex {
     /// editable, re-harvested-on-save packages from the read-only depot set.
     #[returns(ref)]
     pub workspaces: Vec<String>,
+    /// What the manifest pinned, as opposed to what the harvest found. Written
+    /// by [`IncrementalDatabase::set_library_deps`], separately from the other
+    /// three — see there for why.
+    #[returns(ref)]
+    pub deps: LibraryDeps,
 }
 
 /// The workspace package's member files as salsa input handles, so the
@@ -1084,9 +1097,41 @@ impl IncrementalDatabase {
             None => {
                 // Creating the singleton input registers it in storage; the
                 // handle is refetched via `try_get` on later calls.
-                let _ = LibraryIndex::builder(packages, roots, workspaces)
+                let _ = LibraryIndex::builder(packages, roots, workspaces, LibraryDeps::default())
                     .durability(Durability::HIGH)
                     .new(self);
+            }
+        }
+    }
+
+    /// Replace what the manifest pinned: every package's version and kind,
+    /// keyed by name, at HIGH durability. Creates the singleton input on first
+    /// call, exactly as [`set_library`](Self::set_library) does, so either may
+    /// run first.
+    ///
+    /// Written separately from `set_library`'s three because it is a different
+    /// map of a different thing: those are products of the *harvest*, keyed by
+    /// what was successfully indexed, while this comes from the *manifest* and
+    /// deliberately carries names that were never indexed at all. Both ride the
+    /// same cadence — one `LibraryMessage::Full` sets both.
+    pub fn set_library_deps(&mut self, deps: BTreeMap<String, PackageMeta>) {
+        let deps = LibraryDeps(deps);
+        match LibraryIndex::try_get(self) {
+            Some(index) => {
+                index
+                    .set_deps(self)
+                    .with_durability(Durability::HIGH)
+                    .to(deps);
+            }
+            None => {
+                let _ = LibraryIndex::builder(
+                    LibraryPackages::default(),
+                    LibraryRoots::default(),
+                    Vec::new(),
+                    deps,
+                )
+                .durability(Durability::HIGH)
+                .new(self);
             }
         }
     }
@@ -1284,6 +1329,13 @@ impl IncrementalDatabase {
             .cloned()
     }
 
+    /// The version and kind the manifest pinned for package `name`, if it
+    /// pinned one. Present for packages whose source was never found, and
+    /// absent for the Base/Core/stdlib floor, which no manifest pins.
+    pub fn package_meta(&self, name: &str) -> Option<PackageMeta> {
+        LibraryIndex::try_get(self)?.deps(self).0.get(name).cloned()
+    }
+
     /// The names of the packages under development (one per workspace folder
     /// that is a package project), empty when none.
     pub fn workspace_packages(&self) -> Vec<String> {
@@ -1431,6 +1483,12 @@ impl Analysis {
     /// located the depot and harvested it.
     pub fn package_root(&self, name: &str) -> Option<PathBuf> {
         self.0.package_root(name)
+    }
+
+    /// The version and kind the manifest pinned for package `name`. See
+    /// [`IncrementalDatabase::package_meta`].
+    pub fn package_meta(&self, name: &str) -> Option<PackageMeta> {
+        self.0.package_meta(name)
     }
 
     /// The names of the packages under development, empty when none.

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -1191,9 +1191,24 @@ impl IncrementalDatabase {
     /// The declared dependencies read off the project file tracked at `path`,
     /// for a caller holding a path rather than a package name — the language
     /// server's gate for whether a project-file keystroke changed anything a
-    /// consumer would notice. `None` for an untracked or unparseable file.
+    /// consumer would notice.
+    ///
+    /// `None` unless `path` is a **workspace package's** project file, as
+    /// registered by [`set_project_files`](Self::set_project_files). An editor
+    /// opens project files that belong to no package — a `docs/Project.toml`, a
+    /// depot one followed from a manifest link — and their text is tracked like
+    /// any other buffer, but nothing reads their `[deps]`. Answering with it
+    /// would re-lint the whole workspace on every character typed in a file no
+    /// consumer has ever asked about.
+    ///
+    /// Also `None` for an untracked or unparseable file.
     pub fn declared_deps_of_file(&self, path: &Path) -> Option<Arc<DeclaredDeps>> {
-        project_declared_deps(self, self.lookup_file(path)?)
+        let file = self.lookup_file(path)?;
+        let claimed = ProjectFiles::try_get(self)?
+            .files(self)
+            .values()
+            .any(|tracked| *tracked == file);
+        claimed.then(|| project_declared_deps(self, file))?
     }
 
     /// The input tracking package `name`'s project file, if one is registered.

--- a/src/index.rs
+++ b/src/index.rs
@@ -151,7 +151,7 @@ fn declared_deps(envs: &[Environment]) -> BTreeMap<String, Arc<DeclaredDeps>> {
             continue;
         };
         out.entry(dev.name)
-            .or_insert_with(|| Arc::new(env.direct_deps.keys().cloned().collect()));
+            .or_insert_with(|| Arc::new(env.declared_deps.clone()));
     }
     out
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -57,7 +57,17 @@ pub struct HarvestedLibrary {
     /// fatou could not locate, still declares its dependencies here. The
     /// linter's `unresolved-import` reads it; a folder that is not a package
     /// project contributes no entry.
+    ///
+    /// The CLI's copy of what the language server derives from the project file
+    /// itself ([`project_declared_deps`](crate::incremental::project_declared_deps)):
+    /// `fatou lint` has no salsa database, and no editor buffer to be stale
+    /// against.
     pub declared_deps: BTreeMap<String, Arc<DeclaredDeps>>,
+    /// Each workspace package's project file, keyed the same way as
+    /// [`declared_deps`](Self::declared_deps). The language server tracks these
+    /// paths as salsa inputs so an *unsaved* `[deps]` edit reaches
+    /// `unresolved-import` without waiting for a save and a re-resolve.
+    pub project_files: BTreeMap<String, PathBuf>,
 }
 
 /// The module names a package's own source files may `using`/`import`: its
@@ -156,6 +166,20 @@ fn declared_deps(envs: &[Environment]) -> BTreeMap<String, Arc<DeclaredDeps>> {
     out
 }
 
+/// Each workspace package's project file, deduped by name exactly like
+/// [`declared_deps`] so the two maps name the same environment for a name.
+fn project_files(envs: &[Environment]) -> BTreeMap<String, PathBuf> {
+    let mut out: BTreeMap<String, PathBuf> = BTreeMap::new();
+    for env in envs {
+        let Some(dev) = env.dev_package() else {
+            continue;
+        };
+        out.entry(dev.name)
+            .or_insert_with(|| env.project_file.clone());
+    }
+    out
+}
+
 /// Harvest several resolved environments (one per workspace folder) into one
 /// merged library. The system index is harvested once, from the first
 /// environment with a located installation; depot packages merge by name with
@@ -194,6 +218,7 @@ pub fn harvest_libraries(envs: &[Environment]) -> HarvestedLibrary {
     }
     lib.workspaces.sort();
     lib.declared_deps = declared_deps(envs);
+    lib.project_files = project_files(envs);
     lib
 }
 
@@ -257,6 +282,7 @@ pub fn harvest_libraries_parallel(
     }
     lib.workspaces.sort();
     lib.declared_deps = declared_deps(envs);
+    lib.project_files = project_files(envs);
     lib
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::environment::Environment;
+use crate::environment::{Environment, PackageMeta};
 
 pub use base::{build_system_index, build_system_library, build_system_library_cached};
 pub use cache::{CacheKey, IndexCache};
@@ -68,6 +68,16 @@ pub struct HarvestedLibrary {
     /// paths as salsa inputs so an *unsaved* `[deps]` edit reaches
     /// `unresolved-import` without waiting for a save and a re-resolve.
     pub project_files: BTreeMap<String, PathBuf>,
+    /// Every manifest-pinned package's version and kind, keyed by name.
+    ///
+    /// Kept beside [`roots`](Self::roots) rather than folded into it because
+    /// the two have different key sets on purpose: `roots` names what was
+    /// *harvested*, this names what the manifest *pinned*. A standard library
+    /// with no located Julia install, or a registered package whose depot slug
+    /// is missing, has an entry here and none there — and "installed, version
+    /// 0.4.5, source not found" is exactly what a reader of that project file
+    /// wants told.
+    pub deps: BTreeMap<String, PackageMeta>,
 }
 
 /// The module names a package's own source files may `using`/`import`: its
@@ -166,6 +176,23 @@ fn declared_deps(envs: &[Environment]) -> BTreeMap<String, Arc<DeclaredDeps>> {
     out
 }
 
+/// Every manifest-pinned package's version and kind across `envs`, first
+/// environment winning a name — the same claim rule the harvest itself uses,
+/// so the two agree on which environment a name came from.
+///
+/// Unfiltered by whether the package's source was found: an unlocatable
+/// package is still pinned, and saying so is the point.
+fn dep_meta(envs: &[Environment]) -> BTreeMap<String, PackageMeta> {
+    let mut out: BTreeMap<String, PackageMeta> = BTreeMap::new();
+    for env in envs {
+        for package in &env.packages {
+            out.entry(package.name.clone())
+                .or_insert_with(|| package.meta());
+        }
+    }
+    out
+}
+
 /// Each workspace package's project file, deduped by name exactly like
 /// [`declared_deps`] so the two maps name the same environment for a name.
 fn project_files(envs: &[Environment]) -> BTreeMap<String, PathBuf> {
@@ -219,6 +246,7 @@ pub fn harvest_libraries(envs: &[Environment]) -> HarvestedLibrary {
     lib.workspaces.sort();
     lib.declared_deps = declared_deps(envs);
     lib.project_files = project_files(envs);
+    lib.deps = dep_meta(envs);
     lib
 }
 
@@ -283,6 +311,7 @@ pub fn harvest_libraries_parallel(
     lib.workspaces.sort();
     lib.declared_deps = declared_deps(envs);
     lib.project_files = project_files(envs);
+    lib.deps = dep_meta(envs);
     lib
 }
 

--- a/src/index/base.rs
+++ b/src/index/base.rs
@@ -168,6 +168,7 @@ fn assemble(results: Vec<(String, Arc<PackageIndex>, PathBuf)>) -> HarvestedLibr
         roots,
         workspaces: Vec::new(),
         declared_deps: BTreeMap::new(),
+        project_files: BTreeMap::new(),
     }
 }
 
@@ -178,6 +179,7 @@ fn fallback_library() -> HarvestedLibrary {
         roots: BTreeMap::new(),
         workspaces: Vec::new(),
         declared_deps: BTreeMap::new(),
+        project_files: BTreeMap::new(),
     }
 }
 

--- a/src/index/base.rs
+++ b/src/index/base.rs
@@ -169,6 +169,7 @@ fn assemble(results: Vec<(String, Arc<PackageIndex>, PathBuf)>) -> HarvestedLibr
         workspaces: Vec::new(),
         declared_deps: BTreeMap::new(),
         project_files: BTreeMap::new(),
+        deps: BTreeMap::new(),
     }
 }
 
@@ -180,6 +181,7 @@ fn fallback_library() -> HarvestedLibrary {
         workspaces: Vec::new(),
         declared_deps: BTreeMap::new(),
         project_files: BTreeMap::new(),
+        deps: BTreeMap::new(),
     }
 }
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -60,6 +60,7 @@ mod hover;
 mod latex_symbols;
 mod lint;
 mod progress;
+mod project_navigation;
 mod pull_diagnostics;
 mod read_jobs;
 mod references;

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -265,6 +265,7 @@ impl AnalysisWorker {
                     guard("library", || match msg {
                         Ok(LibraryMessage::Full(lib)) => {
                             self.db.set_project_files(lib.project_files);
+                            self.db.set_library_deps(lib.deps);
                             self.db.set_library(lib.packages, lib.roots, lib.workspaces);
                             // Seed the workspace packages' member files as inputs
                             // so cross-file references/rename can index them.

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -271,6 +271,12 @@ impl AnalysisWorker {
                             // so cross-file references/rename can index them.
                             self.db.seed_workspace_members();
                             self.refresh_graph_diagnostics();
+                            // `set_library_deps` above is where a `[deps]` inlay
+                            // hint's version comes from, and it lands well after
+                            // any `Project.toml` the user opened at startup. A
+                            // single-package swap leaves that map alone, so this
+                            // rides the full harvest only.
+                            let _ = self.out_tx.send(Outbound::InlayHintsRefresh);
                         }
                         Ok(LibraryMessage::Package { name, index }) => {
                             self.db.set_package_index(name, index);

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -20,8 +20,9 @@ use crossbeam_channel::{Receiver, Sender, select};
 use lsp_types::{Diagnostic, Uri};
 use salsa::Database as _;
 
+use crate::environment::is_project_file;
 use crate::incremental::{IncrementalDatabase, IncrementalDb};
-use crate::index::{HarvestedLibrary, PackageIndex};
+use crate::index::{DeclaredDeps, HarvestedLibrary, PackageIndex};
 use crate::parser::Edit;
 use crate::text::{PositionEncoding, TextBuffer};
 
@@ -72,6 +73,20 @@ pub(crate) struct AnalysisRequest {
     pub(crate) edits: Option<Vec<Edit>>,
 }
 
+/// A write to the tracked text of a file the analysis pipeline does not own —
+/// the route to the sole salsa writer for anything that is not a Julia
+/// analysis.
+pub(crate) enum SyncMessage {
+    /// Revert this path's tracked input to on-disk text: a document closed (its
+    /// discarded buffer must not linger in the reverse-occurrence index) or a
+    /// watched file changed outside any open buffer.
+    Revert(PathBuf),
+    /// Track this text for `path`: an open project-file buffer, which is never
+    /// dispatched as an analysis (it is not Julia) but whose `[deps]` the
+    /// linter reads through `project_declared_deps`.
+    SetText { path: PathBuf, text: String },
+}
+
 /// A library-index update delivered to the analysis thread by the background
 /// harvester. The full harvest lands once at startup; a re-harvest of the
 /// workspace package (on save) lands as a single-package swap.
@@ -96,7 +111,7 @@ pub(crate) fn spawn_analysis_thread(
     analysis_rx: Receiver<AnalysisRequest>,
     read_rx: Receiver<ReadJob>,
     library_rx: Receiver<LibraryMessage>,
-    sync_rx: Receiver<PathBuf>,
+    sync_rx: Receiver<SyncMessage>,
     out_tx: Sender<Outbound>,
     read_spawner: Spawner,
     encoding: PositionEncoding,
@@ -220,22 +235,26 @@ impl AnalysisWorker {
         analysis_rx: &Receiver<AnalysisRequest>,
         read_rx: &Receiver<ReadJob>,
         library_rx: &Receiver<LibraryMessage>,
-        sync_rx: &Receiver<PathBuf>,
+        sync_rx: &Receiver<SyncMessage>,
         done_rx: &Receiver<AnalyzeDone>,
     ) {
         loop {
             select! {
-                recv(sync_rx) -> path => {
-                    // An editor closed a document, or a watched file changed
-                    // outside any open buffer: revert its tracked input to
-                    // on-disk text so a discarded buffer (or stale seeded text)
-                    // stops contributing to the reverse-occurrence index. A
-                    // no-op for a non-member or a buffer already matching disk.
-                    // Guarded so a panic mid-revert can't kill the sole writer.
-                    guard("sync", || {
-                        if let Ok(path) = path {
-                            self.on_sync(&path, analysis_rx);
+                recv(sync_rx) -> msg => {
+                    // A write to a file the analysis pipeline does not own.
+                    // Guarded so a panic mid-write can't kill the sole writer.
+                    guard("sync", || match msg {
+                        // An editor closed a document, or a watched file changed
+                        // outside any open buffer: revert its tracked input to
+                        // on-disk text so a discarded buffer (or stale seeded
+                        // text) stops contributing to the reverse-occurrence
+                        // index. A no-op for a non-member or a buffer already
+                        // matching disk.
+                        Ok(SyncMessage::Revert(path)) => self.on_sync(&path, analysis_rx),
+                        Ok(SyncMessage::SetText { path, text }) => {
+                            self.on_project_text(&path, text);
                         }
+                        Err(_) => {}
                     });
                 }
                 recv(library_rx) -> msg => {
@@ -337,10 +356,47 @@ impl AnalysisWorker {
         {
             self.active = None;
         }
+        let declared_before = self.declared_deps_of(path);
         self.db.revert_file_to_disk(path);
+        // Closing an unsaved `Project.toml` puts the disk copy back in charge,
+        // which can change what the package declares.
+        self.refresh_if_declared_deps_changed(path, declared_before);
         // The drain above swallowed the `analyze` arm's wake-up for whatever
         // else it picked up, so those requests are dispatched from here.
         self.try_dispatch();
+    }
+
+    /// Track an open project file's buffer text. The buffer is authoritative
+    /// over the disk copy from here on, so an unsaved `[deps]` edit reaches
+    /// `unresolved-import` across the package without a save — the harvester's
+    /// own re-resolve reads disk, but never clobbers a tracked input.
+    fn on_project_text(&mut self, path: &Path, text: String) {
+        let declared_before = self.declared_deps_of(path);
+        self.db.upsert_file(path, text);
+        self.refresh_if_declared_deps_changed(path, declared_before);
+    }
+
+    /// The declared dependencies `path` contributes, or `None` when it is not a
+    /// project file at all — so a `.jl` sync never pays for a TOML parse.
+    fn declared_deps_of(&self, path: &Path) -> Option<Arc<DeclaredDeps>> {
+        is_project_file(path)
+            .then(|| self.db.declared_deps_of_file(path))
+            .flatten()
+    }
+
+    /// Nudge the open documents when a write to `path` changed what its package
+    /// declares. Gated on the declared set rather than on the text: typing in
+    /// `[compat]`, or anywhere else in the file, must cost nothing beyond the
+    /// one memoized TOML parse.
+    ///
+    /// Emitted from this thread *after* the write, so a pull client's re-pull
+    /// cannot be served against the older revision — the ordering
+    /// [`refresh_graph_diagnostics`](Self::refresh_graph_diagnostics) already
+    /// relies on.
+    fn refresh_if_declared_deps_changed(&self, path: &Path, before: Option<Arc<DeclaredDeps>>) {
+        if self.declared_deps_of(path) != before {
+            let _ = self.out_tx.send(Outbound::DiagnosticsRefresh);
+        }
     }
 
     /// Add `req` to the pending queue, keeping the highest version per URI

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -245,7 +245,7 @@ impl AnalysisWorker {
                     // diagnostic depends on the library yet.
                     guard("library", || match msg {
                         Ok(LibraryMessage::Full(lib)) => {
-                            self.db.set_declared_deps(lib.declared_deps);
+                            self.db.set_project_files(lib.project_files);
                             self.db.set_library(lib.packages, lib.roots, lib.workspaces);
                             // Seed the workspace packages' member files as inputs
                             // so cross-file references/rename can index them.

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -384,7 +384,10 @@ impl AnalysisWorker {
     }
 
     /// The declared dependencies `path` contributes, or `None` when it is not a
-    /// project file at all — so a `.jl` sync never pays for a TOML parse.
+    /// project file at all — so a `.jl` sync never pays for a TOML parse — and
+    /// likewise `None` for one no workspace package claims, whose `[deps]` no
+    /// consumer reads (see
+    /// [`declared_deps_of_file`](IncrementalDatabase::declared_deps_of_file)).
     fn declared_deps_of(&self, path: &Path) -> Option<Arc<DeclaredDeps>> {
         is_project_file(path)
             .then(|| self.db.declared_deps_of_file(path))

--- a/src/lsp/definition.rs
+++ b/src/lsp/definition.rs
@@ -491,7 +491,10 @@ fn library_locations<P: PackageSource>(
 /// Materialize on-disk `(path, span)` sites into [`Location`]s, reading each
 /// distinct file once (methods of one group can span the include closure).
 /// Unreadable files are skipped; the result is ordered by path, then offset.
-fn site_locations(mut sites: Vec<(PathBuf, Span)>, encoding: PositionEncoding) -> Vec<Location> {
+pub(super) fn site_locations(
+    mut sites: Vec<(PathBuf, Span)>,
+    encoding: PositionEncoding,
+) -> Vec<Location> {
     sites.sort_by(|a, b| (&a.0, a.1.start).cmp(&(&b.0, b.1.start)));
     sites.dedup();
     let mut out = Vec::new();

--- a/src/lsp/definition.rs
+++ b/src/lsp/definition.rs
@@ -34,7 +34,7 @@ use lsp_types::{Location, Position, Range, Uri};
 use rowan::{TextRange, TextSize};
 use smol_str::SmolStr;
 
-use crate::incremental::Analysis;
+use crate::incremental::{Analysis, normalize_path};
 use crate::index::model::{DefLocation, Span};
 use crate::index::{ModuleIndex, PackageIndex};
 use crate::parser::parse;
@@ -491,10 +491,20 @@ fn library_locations<P: PackageSource>(
 /// Materialize on-disk `(path, span)` sites into [`Location`]s, reading each
 /// distinct file once (methods of one group can span the include closure).
 /// Unreadable files are skipped; the result is ordered by path, then offset.
+///
+/// Paths are normalized **first**, before the sort: a `dev`'d dependency's
+/// source root is the manifest's `path` joined to the project directory, so it
+/// keeps that entry's `../` spelling, and the filesystem resolves it while a
+/// URI does not — the client compares URIs textually and would open a second
+/// tab onto a file it already has. Normalizing up front also makes two
+/// spellings of one file collapse into a single chunk, so it is read once.
 pub(super) fn site_locations(
     mut sites: Vec<(PathBuf, Span)>,
     encoding: PositionEncoding,
 ) -> Vec<Location> {
+    for (path, _) in &mut sites {
+        *path = normalize_path(path);
+    }
     sites.sort_by(|a, b| (&a.0, a.1.start).cmp(&(&b.0, b.1.start)));
     sites.dedup();
     let mut out = Vec::new();
@@ -704,6 +714,34 @@ mod tests {
         // The `greet` definition on line 2, column 0 of the depot source.
         assert_eq!(loc.range.start, Position::new(2, 0));
         assert_eq!(loc.range.end, Position::new(2, 5));
+    }
+
+    /// A `dev`'d dependency's source root is the manifest's `path` joined to
+    /// the project directory, so it keeps that entry's `../` spelling. The jump
+    /// must still name the file under the string the client already knows it
+    /// by: a URI is compared textually, and one carrying a `..` opens a second
+    /// editor tab onto the same file.
+    #[test]
+    fn a_root_spelled_with_dot_dot_names_the_real_file() {
+        let tmp = TempDir::new();
+        let entry = tmp.path.join("src").join("Greetings.jl");
+        fs::create_dir_all(entry.parent().unwrap()).unwrap();
+        fs::write(
+            &entry,
+            "module Greetings\nexport greet\ngreet(name) = name\nend\n",
+        )
+        .unwrap();
+
+        let pkg = harvest_package_named(&tmp.path, "Greetings");
+        let mut lib = TestLib::default();
+        lib.packages.insert("Greetings".to_string(), Arc::new(pkg));
+        // The same root, reached the way a path-pinned manifest entry spells it.
+        lib.roots
+            .insert("Greetings".to_string(), tmp.path.join("src").join(".."));
+
+        let loc = single_def_at("using Greetings\ngreet|(1)", &lib).unwrap();
+        assert_eq!(to_path(&loc.uri), Some(entry));
+        assert_eq!(loc.range.start, Position::new(2, 0));
     }
 
     #[test]

--- a/src/lsp/document_link.rs
+++ b/src/lsp/document_link.rs
@@ -50,11 +50,7 @@ pub(crate) fn document_links_via_db(
     // A synthetic path stands in for a non-`file` URI (an untitled buffer): its
     // parent names no real directory, so a relative include has nothing to
     // anchor to and gets no link.
-    let base_dir = if uri::is_synthetic(path) {
-        None
-    } else {
-        path.parent().filter(|dir| !dir.as_os_str().is_empty())
-    };
+    let base_dir = uri::anchor_dir(path);
     let cached = salsa::Cancelled::catch(AssertUnwindSafe(|| {
         let file = snapshot.lookup_file(path)?;
         if snapshot.file_text(file) != text {

--- a/src/lsp/environment_diagnostics.rs
+++ b/src/lsp/environment_diagnostics.rs
@@ -43,6 +43,31 @@ pub(crate) fn environment_diagnostics(
     out
 }
 
+/// The diagnostics an open environment-file *buffer* carries on its own: the
+/// text-only checks, which need no resolved [`Environment`] and so run at edit
+/// cadence on the main loop rather than on the harvester's save/watch cadence.
+///
+/// That is the whole of what a buffer can answer. The semantic checks stay with
+/// [`environment_diagnostics`] above, because a resolved environment exists
+/// only on the harvester thread, which reads disk — the line stage 2 drew. The
+/// parse is a TOML parse of a file measured in kilobytes, which is why it can
+/// sit on the main loop at all.
+pub(crate) fn buffer_diagnostics(
+    path: &Path,
+    text: &str,
+    encoding: PositionEncoding,
+) -> Vec<Diagnostic> {
+    let findings = project_files::syntax_findings(path, text);
+    if findings.is_empty() {
+        return Vec::new();
+    }
+    let line_index = LineIndex::new(text);
+    findings
+        .iter()
+        .map(|finding| to_lsp(finding, &line_index, encoding))
+        .collect()
+}
+
 /// The findings for a resolve that failed outright. Placed on the file the
 /// error names, which is the only thing known about a project that could not be
 /// read: no [`Environment`] exists to check.
@@ -139,6 +164,35 @@ mod tests {
         assert!(
             diag.code_description.is_none(),
             "a check ID names no reference section"
+        );
+    }
+
+    /// The buffer route reports what a text alone can decide, and stays silent
+    /// on a file that parses — the semantic checks are the harvester's, since
+    /// only it has a resolved environment.
+    #[test]
+    fn the_buffer_route_reports_syntax_alone() {
+        let path = PathBuf::from("/work/Project.toml");
+        let diags =
+            buffer_diagnostics(&path, "name = \"Demo\"\nuuid = \n", PositionEncoding::Utf16);
+        let [diag] = &diags[..] else {
+            panic!("expected one diagnostic, got {diags:?}");
+        };
+        assert_eq!(diag.range.start.line, 1);
+        assert_eq!(
+            diag.code,
+            Some(NumberOrString::String("toml-syntax".to_string()))
+        );
+
+        // A package with no `[compat]` bound on `julia` is a *semantic*
+        // finding: it needs a resolved environment, so the buffer says nothing.
+        assert!(
+            buffer_diagnostics(
+                &path,
+                "name = \"Demo\"\nuuid = \"00000000-0000-0000-0000-000000000001\"\n",
+                PositionEncoding::Utf16,
+            )
+            .is_empty()
         );
     }
 

--- a/src/lsp/project_navigation.rs
+++ b/src/lsp/project_navigation.rs
@@ -25,7 +25,8 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 
 use lsp_types::{
-    DocumentLink, Hover, HoverContents, Location, MarkupContent, MarkupKind, Position, Range,
+    DocumentLink, Hover, HoverContents, InlayHint, InlayHintLabel, InlayHintTooltip, Location,
+    MarkupContent, MarkupKind, Position, Range,
 };
 use rowan::TextRange;
 
@@ -210,6 +211,73 @@ pub(crate) fn project_document_links_via_db(
 ) -> Vec<DocumentLink> {
     salsa::Cancelled::catch(AssertUnwindSafe(|| {
         project_document_links(text, encoding, snapshot)
+    }))
+    .unwrap_or_default()
+}
+
+/// Inlay hints in a project file: each dependency's resolved version, after its
+/// UUID.
+///
+/// The `[deps]` table is almost entirely UUID, and the one fact a reader wants
+/// from it — which version am I actually on — lives in the `Manifest.toml` next
+/// door, which nobody opens. Hover answers that one dependency at a time and
+/// only when asked; this answers all of them at once and passively, which is
+/// what the two features are respectively for.
+///
+/// Only the version is shown. The kind belongs to the question "tell me about
+/// *this* dependency", which is hover's, and repeating "Registered package"
+/// down the table is noise. A dependency with no resolved version — an
+/// uninstantiated project — gets no hint rather than an empty one.
+pub(crate) fn project_inlay_hints<L: ProjectLibrary>(
+    text: &TextBuffer,
+    range: Range,
+    encoding: PositionEncoding,
+    library: &L,
+) -> Vec<InlayHint> {
+    let line_index = text.line_index();
+    // The client asks for its viewport and re-asks on scroll and on edit, so a
+    // hint outside it is dropped rather than computed and thrown away.
+    let start = line_index.position_to_byte(range.start, encoding);
+    let end = line_index.position_to_byte(range.end, encoding);
+    dep_entries(text)
+        .into_iter()
+        .filter_map(|dep| {
+            let at = usize::from(dep.uuid_range.end());
+            if at < start || at > end {
+                return None;
+            }
+            let version = library.package_meta(&dep.name)?.version?;
+            Some(InlayHint {
+                position: line_index.byte_to_position(at, encoding),
+                label: InlayHintLabel::String(format!("v{version}")),
+                // No kind: neither `Type` nor `Parameter` describes a version,
+                // and the spec has the client style an absent one sensibly.
+                kind: None,
+                text_edits: None,
+                // The rest of what hover would say, so the hint itself hovers.
+                tooltip: dep_markdown(&dep.name, library).map(|value| {
+                    InlayHintTooltip::MarkupContent(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value,
+                    })
+                }),
+                padding_left: Some(true),
+                padding_right: None,
+                data: None,
+            })
+        })
+        .collect()
+}
+
+/// [`project_inlay_hints`] against a database snapshot.
+pub(crate) fn project_inlay_hints_via_db(
+    snapshot: &Analysis,
+    text: &TextBuffer,
+    range: Range,
+    encoding: PositionEncoding,
+) -> Vec<InlayHint> {
+    salsa::Cancelled::catch(AssertUnwindSafe(|| {
+        project_inlay_hints(text, range, encoding, snapshot)
     }))
     .unwrap_or_default()
 }
@@ -487,6 +555,98 @@ Greetings = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
         let (_tmp, lib, _entry) = greetings();
         let text = TextBuffer::new("[deps\nGreetings = \"1520ce14\"\n".to_string());
         assert!(project_document_links(&text, PositionEncoding::Utf16, &lib).is_empty());
+    }
+
+    // --- Inlay hints --------------------------------------------------------
+
+    /// The whole viewport, for a test that is not about the range filter.
+    const WHOLE_FILE: Range = Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: u32::MAX,
+            character: 0,
+        },
+    };
+
+    /// A hint's label. `InlayHintLabel` implements no `PartialEq`, so a test
+    /// compares the string it carries.
+    fn label(hint: &InlayHint) -> &str {
+        match &hint.label {
+            InlayHintLabel::String(text) => text,
+            other => panic!("expected a plain string label, got {other:?}"),
+        }
+    }
+
+    /// A two-dependency project: `Greetings` resolved to a version, `Silent`
+    /// pinned but never instantiated.
+    fn two_deps() -> (TextBuffer, TestLib) {
+        let text = TextBuffer::new(format!(
+            "{PROJECT}Silent = \"682c06a0-de6a-54ab-a142-c8b1cf79cde6\"\n"
+        ));
+        let mut lib = TestLib::default();
+        lib.deps.insert(
+            "Greetings".to_string(),
+            meta(Some("0.4.5"), PackageKind::Registered),
+        );
+        lib.deps
+            .insert("Silent".to_string(), meta(None, PackageKind::Registered));
+        (text, lib)
+    }
+
+    /// The version lands after the UUID, which is the end of the line — and a
+    /// dependency with no resolved version contributes nothing rather than an
+    /// empty hint.
+    #[test]
+    fn each_resolved_dependency_shows_its_version() {
+        let (text, lib) = two_deps();
+        let hints = project_inlay_hints(&text, WHOLE_FILE, PositionEncoding::Utf16, &lib);
+
+        let [hint] = &hints[..] else {
+            panic!("expected exactly one hint, got {hints:?}");
+        };
+        assert_eq!(label(hint), "v0.4.5");
+        let deps_line = text.lines().nth(3).expect("the Greetings line");
+        assert_eq!(
+            hint.position,
+            Position::new(3, u32::try_from(deps_line.len()).unwrap()),
+        );
+        assert_eq!(hint.padding_left, Some(true));
+        // The hint itself hovers, with the rest of what hover would say.
+        assert!(matches!(
+            &hint.tooltip,
+            Some(InlayHintTooltip::MarkupContent(markup))
+                if markup.value.contains("Registered package"),
+        ));
+    }
+
+    /// The client asks for its viewport and re-asks on every scroll, so a hint
+    /// outside it is never built.
+    #[test]
+    fn hints_outside_the_viewport_are_dropped() {
+        let (text, mut lib) = two_deps();
+        lib.deps.insert(
+            "Silent".to_string(),
+            meta(Some("0.21.4"), PackageKind::Registered),
+        );
+
+        // Only the second dependency's line.
+        let viewport = Range::new(Position::new(4, 0), Position::new(5, 0));
+        let hints = project_inlay_hints(&text, viewport, PositionEncoding::Utf16, &lib);
+        assert_eq!(hints.iter().map(label).collect::<Vec<_>>(), vec!["v0.21.4"],);
+    }
+
+    #[test]
+    fn a_broken_project_file_has_no_hints() {
+        let (_tmp, mut lib, _entry) = greetings();
+        lib.deps.insert(
+            "Greetings".to_string(),
+            meta(Some("0.4.5"), PackageKind::Registered),
+        );
+        let text = TextBuffer::new("[deps\nGreetings = \"1520ce14\"\n".to_string());
+        assert!(project_inlay_hints(&text, WHOLE_FILE, PositionEncoding::Utf16, &lib).is_empty());
     }
 
     #[test]

--- a/src/lsp/project_navigation.rs
+++ b/src/lsp/project_navigation.rs
@@ -24,15 +24,34 @@
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 
-use lsp_types::{Location, Position};
+use lsp_types::{Hover, HoverContents, Location, MarkupContent, MarkupKind, Position, Range};
+use rowan::TextRange;
 
+use crate::environment::{PackageKind, PackageMeta};
 use crate::incremental::{Analysis, normalize_path};
 use crate::index::Span;
 use crate::project_files::dep_at;
 use crate::resolve::PackageSource;
-use crate::text::{PositionEncoding, TextBuffer};
+use crate::text::{LineIndex, PositionEncoding, TextBuffer};
 
 use super::definition::site_locations;
+
+/// What a project file's features need to know about a dependency: where its
+/// source is, and what the manifest pinned for it.
+///
+/// The second half is not on [`PackageSource`] because that trait is
+/// resolution's contract — the masking order every consumer of a *name* shares
+/// — and a version has no part in resolving one. This is the project file's own
+/// view, so it lives with the project file's own features.
+pub(crate) trait ProjectLibrary: PackageSource {
+    fn package_meta(&self, name: &str) -> Option<PackageMeta>;
+}
+
+impl ProjectLibrary for Analysis {
+    fn package_meta(&self, name: &str) -> Option<PackageMeta> {
+        Analysis::package_meta(self, name)
+    }
+}
 
 /// Where package `name`'s source begins: its entry file, and the range of the
 /// `module <Name>` token inside it.
@@ -89,6 +108,77 @@ pub(crate) fn project_definition_via_db(
     .unwrap_or_default()
 }
 
+/// Hover in a project file: a dependency name reports what the environment
+/// resolved it to. Any other position answers nothing.
+pub(crate) fn project_hover<L: ProjectLibrary>(
+    text: &TextBuffer,
+    position: Position,
+    encoding: PositionEncoding,
+    library: &L,
+) -> Option<Hover> {
+    let line_index = text.line_index();
+    let offset = line_index.position_to_byte(position, encoding);
+    let dep = dep_at(text, offset)?;
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: dep_markdown(&dep.name, library)?,
+        }),
+        range: Some(to_range(dep.name_range, &line_index, encoding)),
+    })
+}
+
+/// [`project_hover`] against a database snapshot.
+pub(crate) fn project_hover_via_db(
+    snapshot: &Analysis,
+    text: &TextBuffer,
+    position: Position,
+    encoding: PositionEncoding,
+) -> Option<Hover> {
+    salsa::Cancelled::catch(AssertUnwindSafe(|| {
+        project_hover(text, position, encoding, snapshot)
+    }))
+    .unwrap_or_default()
+}
+
+/// What is known about the dependency `name`: its version, how it was pinned,
+/// and where its source landed. Each line is dropped when unknown, and a name
+/// nothing is known about hovers to nothing at all — that it is missing from
+/// the manifest is `missing-from-manifest`'s report to make, not this one's.
+fn dep_markdown<L: ProjectLibrary>(name: &str, library: &L) -> Option<String> {
+    let meta = library.package_meta(name);
+    let root = library.package_root(name);
+    if meta.is_none() && root.is_none() {
+        return None;
+    }
+    let mut out = format!("**{name}**");
+    if let Some(version) = meta.as_ref().and_then(|meta| meta.version.as_deref()) {
+        out.push_str(" v");
+        out.push_str(version);
+    }
+    if let Some(meta) = &meta {
+        out.push_str("\n\n");
+        out.push_str(match meta.kind {
+            PackageKind::Registered => "Registered package",
+            PackageKind::Dev => "Development dependency",
+            PackageKind::Stdlib => "Standard library",
+        });
+    }
+    if let Some(root) = root {
+        // Normalized for the same reason the jump target is: a `dev`'d root
+        // keeps the manifest's `../` spelling, which is not a path to show.
+        out.push_str(&format!("\n\n`{}`", normalize_path(&root).display()));
+    }
+    Some(out)
+}
+
+fn to_range(range: TextRange, line_index: &LineIndex, encoding: PositionEncoding) -> Range {
+    Range {
+        start: line_index.byte_to_position(range.start().into(), encoding),
+        end: line_index.byte_to_position(range.end().into(), encoding),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -130,6 +220,7 @@ mod tests {
     struct TestLib {
         packages: BTreeMap<String, Arc<PackageIndex>>,
         roots: BTreeMap<String, PathBuf>,
+        deps: BTreeMap<String, PackageMeta>,
     }
 
     impl PackageSource for TestLib {
@@ -141,6 +232,19 @@ mod tests {
         }
         fn workspace_member(&self, _path: &Path) -> Option<(Arc<PackageIndex>, ModulePath)> {
             None
+        }
+    }
+
+    impl ProjectLibrary for TestLib {
+        fn package_meta(&self, name: &str) -> Option<PackageMeta> {
+            self.deps.get(name).cloned()
+        }
+    }
+
+    fn meta(version: Option<&str>, kind: PackageKind) -> PackageMeta {
+        PackageMeta {
+            version: version.map(str::to_string),
+            kind,
         }
     }
 
@@ -223,5 +327,98 @@ Greetings = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
         let (_tmp, lib, _entry) = greetings();
         let marked = "[deps\nGreet|ings = \"1520ce14\"\n";
         assert!(def_at(marked, &lib).is_empty());
+    }
+
+    // --- Hover --------------------------------------------------------------
+
+    /// Hover at the position marked by `|`, as markdown.
+    fn hover_at(marked: &str, lib: &TestLib) -> Option<String> {
+        let offset = marked.find('|').expect("a cursor marker");
+        let text = TextBuffer::new(marked.replacen('|', "", 1));
+        let position = text
+            .line_index()
+            .byte_to_position(offset, PositionEncoding::Utf16);
+        let hover = project_hover(&text, position, PositionEncoding::Utf16, lib)?;
+        // The hover covers exactly the dependency name it reports on.
+        assert_eq!(
+            hover.range,
+            Some(Range::new(Position::new(3, 0), Position::new(3, 9))),
+        );
+        match hover.contents {
+            HoverContents::Markup(markup) => Some(markup.value),
+            other => panic!("expected markdown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_dependency_hover_reports_version_kind_and_path() {
+        let (tmp, mut lib, _entry) = greetings();
+        lib.deps.insert(
+            "Greetings".to_string(),
+            meta(Some("0.4.5"), PackageKind::Registered),
+        );
+
+        let marked = PROJECT.replace("Greetings =", "Greet|ings =");
+        assert_eq!(
+            hover_at(&marked, &lib),
+            Some(format!(
+                "**Greetings** v0.4.5\n\nRegistered package\n\n`{}`",
+                tmp.path.display()
+            )),
+        );
+    }
+
+    /// Each line is dropped when unknown: an uninstantiated project pins no
+    /// version, and a package whose source was not found has no path.
+    #[test]
+    fn an_unknown_version_or_path_is_simply_omitted() {
+        let marked = PROJECT.replace("Greetings =", "Greet|ings =");
+
+        let mut lib = TestLib::default();
+        lib.deps
+            .insert("Greetings".to_string(), meta(None, PackageKind::Stdlib));
+        assert_eq!(
+            hover_at(&marked, &lib),
+            Some("**Greetings**\n\nStandard library".to_string()),
+        );
+
+        lib.deps
+            .insert("Greetings".to_string(), meta(None, PackageKind::Dev));
+        assert_eq!(
+            hover_at(&marked, &lib),
+            Some("**Greetings**\n\nDevelopment dependency".to_string()),
+        );
+    }
+
+    /// A name the environment knows nothing about hovers to nothing. That it is
+    /// absent from the manifest is `missing-from-manifest`'s report to make.
+    #[test]
+    fn a_dependency_nothing_is_known_about_has_no_hover() {
+        let marked = PROJECT.replace("Greetings =", "Greet|ings =");
+        assert_eq!(hover_at(&marked, &TestLib::default()), None);
+    }
+
+    #[test]
+    fn nothing_else_in_the_file_hovers() {
+        let (_tmp, mut lib, _entry) = greetings();
+        lib.deps.insert(
+            "Greetings".to_string(),
+            meta(Some("0.4.5"), PackageKind::Registered),
+        );
+        for marked in [
+            PROJECT.replace("name =", "na|me ="),
+            PROJECT.replace("[deps]", "[de|ps]"),
+            PROJECT.replace("\"1520ce14", "\"1520|ce14"),
+        ] {
+            let offset = marked.find('|').expect("a cursor marker");
+            let text = TextBuffer::new(marked.replacen('|', "", 1));
+            let position = text
+                .line_index()
+                .byte_to_position(offset, PositionEncoding::Utf16);
+            assert!(
+                project_hover(&text, position, PositionEncoding::Utf16, &lib).is_none(),
+                "for {marked:?}"
+            );
+        }
     }
 }

--- a/src/lsp/project_navigation.rs
+++ b/src/lsp/project_navigation.rs
@@ -70,10 +70,9 @@ impl ProjectLibrary for Analysis {
 fn package_entry<P: PackageSource>(packages: &P, name: &str) -> Option<(PathBuf, Span)> {
     let root = packages.package_root(name)?;
     let package = packages.package(name)?;
-    // Normalized, because a `dev`'d dependency's root is the manifest's `path`
-    // joined to the project directory and keeps its `../` spelling. A URI
-    // carrying one names the right file under a different string, which is
-    // exactly the identity the client keys its open documents on.
+    // Normalized here rather than left to `site_locations`, which does the same
+    // for the same reason: document links build their URI straight from this
+    // path, and the two features must name a file identically.
     let entry = normalize_path(&root.join(&package.root.loc.file));
     Some((entry, package.root.loc.range))
 }

--- a/src/lsp/project_navigation.rs
+++ b/src/lsp/project_navigation.rs
@@ -16,13 +16,13 @@
 //! map, which is HIGH durability and always current. What remains is the
 //! `salsa::Cancelled` guard, since a write may still race the read.
 //!
-//! A `Manifest.toml` answers none of this. It is not written to the database at
-//! all (nothing reads one without an environment resolve), and its `path`
-//! entries carry no spans — the manifest is deliberately parsed against a plain
-//! table, since its 1.0 and 2.0 layouts differ.
+//! A `Manifest.toml` answers exactly one of them, [`manifest_document_links`],
+//! and it rides no database at all: a manifest is never written to one (nothing
+//! reads a manifest without an environment resolve), and a link on a `path`
+//! entry is decided by the buffer and the filesystem alone.
 
 use std::panic::AssertUnwindSafe;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use lsp_types::{
     DocumentLink, Hover, HoverContents, InlayHint, InlayHintLabel, InlayHintTooltip, Location,
@@ -30,10 +30,10 @@ use lsp_types::{
 };
 use rowan::TextRange;
 
-use crate::environment::{PackageKind, PackageMeta};
+use crate::environment::{PackageKind, PackageMeta, project_file_in, resolve_dev_path};
 use crate::incremental::{Analysis, normalize_path};
 use crate::index::Span;
-use crate::project_files::{dep_at, dep_entries};
+use crate::project_files::{dep_at, dep_entries, manifest_paths};
 use crate::resolve::PackageSource;
 use crate::text::{LineIndex, PositionEncoding, TextBuffer};
 
@@ -213,6 +213,55 @@ pub(crate) fn project_document_links_via_db(
         project_document_links(text, encoding, snapshot)
     }))
     .unwrap_or_default()
+}
+
+/// Document links in an open *manifest*: every `path = "..."` entry links to
+/// the `dev`'d package it pins.
+///
+/// The only feature a manifest answers, and the only thing in one that anchors
+/// anywhere: `path` is the sole entry field naming something outside the file.
+/// It needs no library and no database — the path is resolved exactly as
+/// [`resolve_dev_path`] resolves it during a harvest, so the link and the
+/// environment cannot disagree about where the package is.
+///
+/// The target is the root's *project file*, not the root itself: a `dev`'d root
+/// is a package, what identifies a package is its `Project.toml`, and a client
+/// cannot open a directory. A root with neither spelling of one is linked
+/// as-is rather than not at all — that it is not a package is a fact worth
+/// walking into, and the `path` may simply be a typo.
+pub(crate) fn manifest_document_links(
+    text: &TextBuffer,
+    path: &Path,
+    encoding: PositionEncoding,
+) -> Vec<DocumentLink> {
+    // A manifest sits beside its project file, so its own directory is the
+    // project directory `resolve_dev_path` resolves against.
+    let Some(base_dir) = uri::anchor_dir(path) else {
+        return Vec::new();
+    };
+    let line_index = text.line_index();
+    manifest_paths(text)
+        .into_iter()
+        .filter_map(|entry| {
+            // An empty path resolves to the manifest's own directory, which is
+            // no package and no link.
+            if entry.path.is_empty() {
+                return None;
+            }
+            // Normalized for the reason the jump targets are: a `path` entry
+            // keeps its `../` spelling, which the filesystem resolves and a URI
+            // does not, and a client comparing URIs textually would open a
+            // second tab onto a file it already has.
+            let root = normalize_path(&resolve_dev_path(base_dir, &entry.path));
+            let target = project_file_in(&root).unwrap_or(root);
+            Some(DocumentLink {
+                range: to_range(entry.range, &line_index, encoding),
+                target: Some(uri::from_path(&target)?),
+                tooltip: None,
+                data: None,
+            })
+        })
+        .collect()
 }
 
 /// Inlay hints in a project file: each dependency's resolved version, after its
@@ -555,6 +604,117 @@ Greetings = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
         let (_tmp, lib, _entry) = greetings();
         let text = TextBuffer::new("[deps\nGreetings = \"1520ce14\"\n".to_string());
         assert!(project_document_links(&text, PositionEncoding::Utf16, &lib).is_empty());
+    }
+
+    // --- Manifest document links --------------------------------------------
+
+    /// A manifest naming `dev`'d `path` entries: one package with a project
+    /// file of its own, one directory without.
+    fn manifest(dir: &Path) -> String {
+        format!(
+            "manifest_format = \"2.0\"\n\n\
+             [[deps.Greetings]]\npath = \"Greetings\"\n\n\
+             [[deps.Bare]]\npath = \"{}\"\n\n\
+             [[deps.AbstractTrees]]\ngit-tree-sha1 = \"deadbeef\"\n",
+            dir.join("Bare").display().to_string().replace('\\', "/"),
+        )
+    }
+
+    fn manifest_links(text: &str, path: &Path) -> Vec<(Range, String)> {
+        manifest_document_links(
+            &TextBuffer::new(text.to_string()),
+            path,
+            PositionEncoding::Utf16,
+        )
+        .into_iter()
+        .map(|link| (link.range, link.target.expect("a link target").to_string()))
+        .collect()
+    }
+
+    /// The link covers the path text, and lands on the root's project file —
+    /// the thing that makes the root a package, and a file a client can open.
+    /// A root with no project file is linked as-is; a registered entry pins no
+    /// path and links nowhere.
+    #[test]
+    fn every_manifest_path_links_to_the_package_it_pins() {
+        let tmp = TempDir::new();
+        fs::create_dir_all(tmp.path.join("Greetings")).unwrap();
+        fs::write(
+            tmp.path.join("Greetings/JuliaProject.toml"),
+            "name = \"Greetings\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path.join("Bare")).unwrap();
+
+        let text = manifest(&tmp.path);
+        let links = manifest_links(&text, &tmp.path.join("Manifest.toml"));
+        assert_eq!(
+            links,
+            vec![
+                (
+                    Range::new(Position::new(3, 8), Position::new(3, 17)),
+                    uri::from_path(&tmp.path.join("Greetings/JuliaProject.toml"))
+                        .unwrap()
+                        .to_string(),
+                ),
+                (
+                    Range::new(
+                        Position::new(6, 8),
+                        Position::new(
+                            6,
+                            u32::try_from(tmp.path.join("Bare").display().to_string().len() + 8)
+                                .unwrap(),
+                        ),
+                    ),
+                    uri::from_path(&tmp.path.join("Bare")).unwrap().to_string(),
+                ),
+            ],
+        );
+    }
+
+    /// The path is resolved the way the environment resolves a `dev`'d root:
+    /// against the manifest's own directory, `../` spellings collapsed rather
+    /// than carried into the URI.
+    #[test]
+    fn a_relative_manifest_path_normalizes_against_the_manifest() {
+        let tmp = TempDir::new();
+        let nested = tmp.path.join("MyPkg");
+        fs::create_dir_all(&nested).unwrap();
+        let text = "[[deps.Greetings]]\npath = \"../Greetings\"\n";
+
+        let links = manifest_links(text, &nested.join("Manifest.toml"));
+        assert_eq!(
+            links,
+            vec![(
+                Range::new(Position::new(1, 8), Position::new(1, 20)),
+                uri::from_path(&tmp.path.join("Greetings"))
+                    .unwrap()
+                    .to_string(),
+            )],
+            "the link names `<tmp>/Greetings`, not `<tmp>/MyPkg/../Greetings`"
+        );
+    }
+
+    /// A synthetic path stands in for a non-`file` URI and anchors no relative
+    /// path, exactly as it does for a Julia document's includes. An empty path
+    /// names the manifest's own directory, which is no package.
+    #[test]
+    fn a_manifest_with_nothing_to_anchor_to_has_no_links() {
+        let untitled = <lsp_types::Uri as std::str::FromStr>::from_str("untitled:Untitled-1")
+            .expect("a valid uri");
+        let text = "[[deps.Greetings]]\npath = \"../Greetings\"\n";
+        assert!(manifest_links(text, &uri::to_path_or_synthetic(&untitled)).is_empty());
+
+        let tmp = TempDir::new();
+        let empty = "[[deps.Greetings]]\npath = \"\"\n";
+        assert!(manifest_links(empty, &tmp.path.join("Manifest.toml")).is_empty());
+    }
+
+    #[test]
+    fn a_broken_manifest_has_no_links() {
+        let tmp = TempDir::new();
+        let text = "[[deps.Greetings\npath = \"../Greetings\"\n";
+        assert!(manifest_links(text, &tmp.path.join("Manifest.toml")).is_empty());
     }
 
     // --- Inlay hints --------------------------------------------------------

--- a/src/lsp/project_navigation.rs
+++ b/src/lsp/project_navigation.rs
@@ -1,0 +1,227 @@
+//! Navigation over an open project file: the language features a
+//! `Project.toml` answers, as opposed to the diagnostics it carries
+//! (`environment_diagnostics`).
+//!
+//! Everything here anchors on a dependency name — [`crate::project_files::dep_at`]
+//! decides what the cursor is on — and resolves it through the harvested
+//! library, which already knows where each package's source lives. That is the
+//! whole feature: a `[deps]` entry is a package name, and the server has a map
+//! from package names to source roots.
+//!
+//! **There is no `compute_*`/`*_via_db` split here**, unlike every Julia
+//! feature. Those exist because a Julia handler can serve a *cached parse tree*
+//! and must fall back when the tracked input lags the live buffer. The parse
+//! here is a TOML parse of the buffer itself, so there is no cache to miss and
+//! nothing to be stale against; the database is consulted only for the library
+//! map, which is HIGH durability and always current. What remains is the
+//! `salsa::Cancelled` guard, since a write may still race the read.
+//!
+//! A `Manifest.toml` answers none of this. It is not written to the database at
+//! all (nothing reads one without an environment resolve), and its `path`
+//! entries carry no spans — the manifest is deliberately parsed against a plain
+//! table, since its 1.0 and 2.0 layouts differ.
+
+use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
+
+use lsp_types::{Location, Position};
+
+use crate::incremental::{Analysis, normalize_path};
+use crate::index::Span;
+use crate::project_files::dep_at;
+use crate::resolve::PackageSource;
+use crate::text::{PositionEncoding, TextBuffer};
+
+use super::definition::site_locations;
+
+/// Where package `name`'s source begins: its entry file, and the range of the
+/// `module <Name>` token inside it.
+///
+/// The harvester already recorded both — the root module's `DefLocation` is
+/// package-root-relative, and `package_root` is what turns it absolute — so
+/// this needs no guess at `src/<Name>.jl`, and it lands on the workspace's own
+/// dev package as readily as on a depot one.
+///
+/// `None` for a package the server never harvested: a standard library with no
+/// located Julia install, or a registered one whose depot slug is missing. The
+/// feature then answers nothing rather than a path that does not exist.
+fn package_entry<P: PackageSource>(packages: &P, name: &str) -> Option<(PathBuf, Span)> {
+    let root = packages.package_root(name)?;
+    let package = packages.package(name)?;
+    // Normalized, because a `dev`'d dependency's root is the manifest's `path`
+    // joined to the project directory and keeps its `../` spelling. A URI
+    // carrying one names the right file under a different string, which is
+    // exactly the identity the client keys its open documents on.
+    let entry = normalize_path(&root.join(&package.root.loc.file));
+    Some((entry, package.root.loc.range))
+}
+
+/// Go-to-definition in a project file: a dependency name jumps to its package's
+/// entry file. Any other position answers nothing.
+pub(crate) fn project_definition<P: PackageSource>(
+    text: &TextBuffer,
+    position: Position,
+    encoding: PositionEncoding,
+    packages: &P,
+) -> Vec<Location> {
+    let offset = text.line_index().position_to_byte(position, encoding);
+    let Some(dep) = dep_at(text, offset) else {
+        return Vec::new();
+    };
+    let Some(site) = package_entry(packages, &dep.name) else {
+        return Vec::new();
+    };
+    site_locations(vec![site], encoding)
+}
+
+/// [`project_definition`] against a database snapshot. A write racing the read
+/// trips `salsa::Cancelled`, which answers nothing — there is no cheaper
+/// fallback to take, since the library map is the only thing consulted.
+pub(crate) fn project_definition_via_db(
+    snapshot: &Analysis,
+    text: &TextBuffer,
+    position: Position,
+    encoding: PositionEncoding,
+) -> Vec<Location> {
+    salsa::Cancelled::catch(AssertUnwindSafe(|| {
+        project_definition(text, position, encoding, snapshot)
+    }))
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::index::{PackageIndex, harvest_package_named};
+    use crate::resolve::ModulePath;
+
+    use super::super::uri::to_path;
+    use super::*;
+
+    /// A unique temp directory removed on drop (mirrors `definition.rs`,
+    /// avoiding a `tempfile` dev-dependency).
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path =
+                std::env::temp_dir().join(format!("fatou-projnav-{}-{}", std::process::id(), n));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[derive(Default)]
+    struct TestLib {
+        packages: BTreeMap<String, Arc<PackageIndex>>,
+        roots: BTreeMap<String, PathBuf>,
+    }
+
+    impl PackageSource for TestLib {
+        fn package(&self, name: &str) -> Option<Arc<PackageIndex>> {
+            self.packages.get(name).cloned()
+        }
+        fn package_root(&self, name: &str) -> Option<PathBuf> {
+            self.roots.get(name).cloned()
+        }
+        fn workspace_member(&self, _path: &Path) -> Option<(Arc<PackageIndex>, ModulePath)> {
+            None
+        }
+    }
+
+    /// A real on-disk `Greetings` package, harvested so its `DefLocation` is
+    /// genuine rather than hand-built.
+    fn greetings() -> (TempDir, TestLib, PathBuf) {
+        let tmp = TempDir::new();
+        let entry = tmp.path.join("src").join("Greetings.jl");
+        fs::create_dir_all(entry.parent().unwrap()).unwrap();
+        fs::write(&entry, "module Greetings\ngreet(name) = name\nend\n").unwrap();
+
+        let mut lib = TestLib::default();
+        lib.packages.insert(
+            "Greetings".to_string(),
+            Arc::new(harvest_package_named(&tmp.path, "Greetings")),
+        );
+        lib.roots.insert("Greetings".to_string(), tmp.path.clone());
+        (tmp, lib, entry)
+    }
+
+    const PROJECT: &str = "\
+name = \"Demo\"
+
+[deps]
+Greetings = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
+";
+
+    /// Go-to-definition at the position marked by `|` (the marker is stripped
+    /// before parsing).
+    fn def_at(marked: &str, lib: &impl PackageSource) -> Vec<Location> {
+        let offset = marked.find('|').expect("a cursor marker");
+        let text = TextBuffer::new(marked.replacen('|', "", 1));
+        let position = text
+            .line_index()
+            .byte_to_position(offset, PositionEncoding::Utf16);
+        project_definition(&text, position, PositionEncoding::Utf16, lib)
+    }
+
+    #[test]
+    fn a_dependency_name_jumps_to_its_entry_file() {
+        let (_tmp, lib, entry) = greetings();
+        let marked = PROJECT.replace("Greetings =", "Greet|ings =");
+
+        let locations = def_at(&marked, &lib);
+        let [location] = &locations[..] else {
+            panic!("expected exactly one location, got {locations:?}");
+        };
+        assert_eq!(to_path(&location.uri), Some(entry));
+        // The `Greetings` of `module Greetings`, line 0, columns 7..16.
+        assert_eq!(location.range.start, Position::new(0, 7));
+        assert_eq!(location.range.end, Position::new(0, 16));
+    }
+
+    /// Every other position in the file is not a dependency name, and none of
+    /// them may jump anywhere.
+    #[test]
+    fn nothing_else_in_the_file_jumps() {
+        let (_tmp, lib, _entry) = greetings();
+        for marked in [
+            PROJECT.replace("name =", "na|me ="),
+            PROJECT.replace("[deps]", "[de|ps]"),
+            PROJECT.replace("\"1520ce14", "\"1520|ce14"),
+        ] {
+            assert!(def_at(&marked, &lib).is_empty(), "for {marked:?}");
+        }
+    }
+
+    /// A package the server never harvested — a standard library with no
+    /// located install, a missing depot slug — has no source to jump to.
+    #[test]
+    fn an_unharvested_dependency_has_no_definition() {
+        let marked = PROJECT.replace("Greetings =", "Greet|ings =");
+        assert!(def_at(&marked, &TestLib::default()).is_empty());
+    }
+
+    /// A `Project.toml` mid-edit does not parse, and a jump from one would be a
+    /// guess. Its `toml-syntax` diagnostic is what reports the state it is in.
+    #[test]
+    fn a_broken_project_file_has_no_definition() {
+        let (_tmp, lib, _entry) = greetings();
+        let marked = "[deps\nGreet|ings = \"1520ce14\"\n";
+        assert!(def_at(marked, &lib).is_empty());
+    }
+}

--- a/src/lsp/project_navigation.rs
+++ b/src/lsp/project_navigation.rs
@@ -24,17 +24,20 @@
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 
-use lsp_types::{Hover, HoverContents, Location, MarkupContent, MarkupKind, Position, Range};
+use lsp_types::{
+    DocumentLink, Hover, HoverContents, Location, MarkupContent, MarkupKind, Position, Range,
+};
 use rowan::TextRange;
 
 use crate::environment::{PackageKind, PackageMeta};
 use crate::incremental::{Analysis, normalize_path};
 use crate::index::Span;
-use crate::project_files::dep_at;
+use crate::project_files::{dep_at, dep_entries};
 use crate::resolve::PackageSource;
 use crate::text::{LineIndex, PositionEncoding, TextBuffer};
 
 use super::definition::site_locations;
+use super::uri;
 
 /// What a project file's features need to know about a dependency: where its
 /// source is, and what the manifest pinned for it.
@@ -170,6 +173,46 @@ fn dep_markdown<L: ProjectLibrary>(name: &str, library: &L) -> Option<String> {
         out.push_str(&format!("\n\n`{}`", normalize_path(&root).display()));
     }
     Some(out)
+}
+
+/// Document links in a project file: every dependency name whose package the
+/// server located becomes a link to that package's entry file.
+///
+/// The same target [`project_definition`] jumps to, through the same
+/// [`package_entry`] join — the two must not drift, since a client offers them
+/// on the same ctrl-click. Purely lexical over the buffer and the library map,
+/// with no I/O, so a link is resolved eagerly and there is no
+/// `documentLink/resolve`.
+pub(crate) fn project_document_links<P: PackageSource>(
+    text: &TextBuffer,
+    encoding: PositionEncoding,
+    packages: &P,
+) -> Vec<DocumentLink> {
+    let line_index = text.line_index();
+    dep_entries(text)
+        .into_iter()
+        .filter_map(|dep| {
+            let (entry, _) = package_entry(packages, &dep.name)?;
+            Some(DocumentLink {
+                range: to_range(dep.name_range, &line_index, encoding),
+                target: Some(uri::from_path(&entry)?),
+                tooltip: None,
+                data: None,
+            })
+        })
+        .collect()
+}
+
+/// [`project_document_links`] against a database snapshot.
+pub(crate) fn project_document_links_via_db(
+    snapshot: &Analysis,
+    text: &TextBuffer,
+    encoding: PositionEncoding,
+) -> Vec<DocumentLink> {
+    salsa::Cancelled::catch(AssertUnwindSafe(|| {
+        project_document_links(text, encoding, snapshot)
+    }))
+    .unwrap_or_default()
 }
 
 fn to_range(range: TextRange, line_index: &LineIndex, encoding: PositionEncoding) -> Range {
@@ -396,6 +439,55 @@ Greetings = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
     fn a_dependency_nothing_is_known_about_has_no_hover() {
         let marked = PROJECT.replace("Greetings =", "Greet|ings =");
         assert_eq!(hover_at(&marked, &TestLib::default()), None);
+    }
+
+    // --- Document links -----------------------------------------------------
+
+    /// One link per located dependency, covering exactly the name and pointing
+    /// where go-to-definition jumps. `[weakdeps]` and `[extras]` name packages
+    /// too, so they link as well.
+    #[test]
+    fn every_located_dependency_becomes_a_link() {
+        let (_tmp, lib, entry) = greetings();
+        let text = TextBuffer::new(format!(
+            "{PROJECT}\n[extras]\nGreetings = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"\n"
+        ));
+
+        let links = project_document_links(&text, PositionEncoding::Utf16, &lib);
+        let target = uri::from_path(&entry).unwrap();
+        assert_eq!(
+            links
+                .iter()
+                .map(|link| (link.range, link.target.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    Range::new(Position::new(3, 0), Position::new(3, 9)),
+                    Some(target.clone())
+                ),
+                (
+                    Range::new(Position::new(6, 0), Position::new(6, 9)),
+                    Some(target)
+                ),
+            ],
+        );
+    }
+
+    /// A dependency the server never located has nothing to link to, and a name
+    /// under the cursor there jumps nowhere either — one join, one answer.
+    #[test]
+    fn an_unlocated_dependency_has_no_link() {
+        let text = TextBuffer::new(PROJECT.to_string());
+        assert!(
+            project_document_links(&text, PositionEncoding::Utf16, &TestLib::default()).is_empty()
+        );
+    }
+
+    #[test]
+    fn a_broken_project_file_has_no_links() {
+        let (_tmp, lib, _entry) = greetings();
+        let text = TextBuffer::new("[deps\nGreetings = \"1520ce14\"\n".to_string());
+        assert!(project_document_links(&text, PositionEncoding::Utf16, &lib).is_empty());
     }
 
     #[test]

--- a/src/lsp/read_jobs.rs
+++ b/src/lsp/read_jobs.rs
@@ -32,6 +32,7 @@ use super::hover::hover_via_db;
 use super::lint::ServerRules;
 use super::project_navigation::{
     project_definition_via_db, project_document_links_via_db, project_hover_via_db,
+    project_inlay_hints_via_db,
 };
 use super::pull_diagnostics::document_diagnostics_via_db;
 use super::references::{document_highlights_via_db, references_via_db};
@@ -220,6 +221,15 @@ pub(crate) enum ReadJob {
         text: Arc<TextBuffer>,
         sender: ReadReply,
     },
+    /// Inlay hints in an open *project file*: each dependency's resolved
+    /// version. `range` is the client's viewport, which it re-sends on every
+    /// scroll, so hints outside it are never built.
+    ProjectInlayHints {
+        id: RequestId,
+        text: Arc<TextBuffer>,
+        range: Range,
+        sender: ReadReply,
+    },
     References {
         id: RequestId,
         uri: Uri,
@@ -328,6 +338,7 @@ impl ReadJob {
             ReadJob::ProjectDefinition { id, sender, .. } => (id, sender),
             ReadJob::ProjectHover { id, sender, .. } => (id, sender),
             ReadJob::ProjectDocumentLinks { id, sender, .. } => (id, sender),
+            ReadJob::ProjectInlayHints { id, sender, .. } => (id, sender),
             ReadJob::References { id, sender, .. } => (id, sender),
             ReadJob::DocumentHighlight { id, sender, .. } => (id, sender),
             ReadJob::PrepareRename { id, sender, .. } => (id, sender),
@@ -579,6 +590,15 @@ pub(crate) fn run_read(snapshot: Analysis, job: ReadJob, encoding: PositionEncod
         ReadJob::ProjectDocumentLinks { id, text, sender } => {
             let links = project_document_links_via_db(&snapshot, &text, encoding);
             let _ = sender.send(Message::Response(Response::new_ok(id, links)));
+        }
+        ReadJob::ProjectInlayHints {
+            id,
+            text,
+            range,
+            sender,
+        } => {
+            let hints = project_inlay_hints_via_db(&snapshot, &text, range, encoding);
+            let _ = sender.send(Message::Response(Response::new_ok(id, hints)));
         }
         ReadJob::References {
             id,

--- a/src/lsp/read_jobs.rs
+++ b/src/lsp/read_jobs.rs
@@ -8,7 +8,7 @@ use lsp_server::{ErrorCode, Message, RequestId, Response};
 use lsp_types::{
     CallHierarchyItem, CodeActionOrCommand, CompletionItem, CompletionResponse,
     DocumentDiagnosticReport, DocumentDiagnosticReportResult, DocumentSymbolResponse, FileRename,
-    FullDocumentDiagnosticReport, GotoDefinitionResponse, Position, Range,
+    FullDocumentDiagnosticReport, GotoDefinitionResponse, Location, Position, Range,
     RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport,
     TypeHierarchyItem, UnchangedDocumentDiagnosticReport, Uri, WorkspaceSymbolResponse,
 };
@@ -30,6 +30,7 @@ use super::folding::folding_ranges_via_db;
 use super::format::{format_edits_via_db, format_range_edits_via_db};
 use super::hover::hover_via_db;
 use super::lint::ServerRules;
+use super::project_navigation::project_definition_via_db;
 use super::pull_diagnostics::document_diagnostics_via_db;
 use super::references::{document_highlights_via_db, references_via_db};
 use super::rename::{prepare_rename_via_db, rename_via_db};
@@ -190,6 +191,16 @@ pub(crate) enum ReadJob {
         position: Position,
         sender: ReadReply,
     },
+    /// Go-to-definition in an open *project file*: a `[deps]` name resolves to
+    /// its package's entry file. No `path`, unlike its Julia twin — the buffer
+    /// is parsed as TOML rather than looked up in the database, and the answer
+    /// points at another file entirely.
+    ProjectDefinition {
+        id: RequestId,
+        text: Arc<TextBuffer>,
+        position: Position,
+        sender: ReadReply,
+    },
     References {
         id: RequestId,
         uri: Uri,
@@ -295,6 +306,7 @@ impl ReadJob {
             ReadJob::Hover { id, sender, .. } => (id, sender),
             ReadJob::SignatureHelp { id, sender, .. } => (id, sender),
             ReadJob::Definition { id, sender, .. } => (id, sender),
+            ReadJob::ProjectDefinition { id, sender, .. } => (id, sender),
             ReadJob::References { id, sender, .. } => (id, sender),
             ReadJob::DocumentHighlight { id, sender, .. } => (id, sender),
             ReadJob::PrepareRename { id, sender, .. } => (id, sender),
@@ -516,16 +528,23 @@ pub(crate) fn run_read(snapshot: Analysis, job: ReadJob, encoding: PositionEncod
             position,
             sender,
         } => {
-            let mut locations =
-                definition_via_db(&snapshot, &uri, &path, &text, position, encoding);
-            // A single site stays scalar (a plain jump); several methods of a
-            // function come back as an array (the client shows a picker).
-            let result = match locations.len() {
-                0 => None,
-                1 => Some(GotoDefinitionResponse::Scalar(locations.remove(0))),
-                _ => Some(GotoDefinitionResponse::Array(locations)),
-            };
-            let _ = sender.send(Message::Response(Response::new_ok(id, result)));
+            let locations = definition_via_db(&snapshot, &uri, &path, &text, position, encoding);
+            let _ = sender.send(Message::Response(Response::new_ok(
+                id,
+                goto_response(locations),
+            )));
+        }
+        ReadJob::ProjectDefinition {
+            id,
+            text,
+            position,
+            sender,
+        } => {
+            let locations = project_definition_via_db(&snapshot, &text, position, encoding);
+            let _ = sender.send(Message::Response(Response::new_ok(
+                id,
+                goto_response(locations),
+            )));
         }
         ReadJob::References {
             id,
@@ -633,5 +652,17 @@ pub(crate) fn run_read(snapshot: Analysis, job: ReadJob, encoding: PositionEncod
             let items = subtypes_via_db(&snapshot, &item, encoding);
             let _ = sender.send(Message::Response(Response::new_ok(id, items)));
         }
+    }
+}
+
+/// Collapse definition sites into a `textDocument/definition` result: none is
+/// `null`, one is a plain jump, several are an array the client offers as a
+/// picker (the methods of a function, say). Shared so the Julia and project-file
+/// routes cannot drift on the shape they answer with.
+fn goto_response(mut locations: Vec<Location>) -> Option<GotoDefinitionResponse> {
+    match locations.len() {
+        0 => None,
+        1 => Some(GotoDefinitionResponse::Scalar(locations.remove(0))),
+        _ => Some(GotoDefinitionResponse::Array(locations)),
     }
 }

--- a/src/lsp/read_jobs.rs
+++ b/src/lsp/read_jobs.rs
@@ -30,7 +30,9 @@ use super::folding::folding_ranges_via_db;
 use super::format::{format_edits_via_db, format_range_edits_via_db};
 use super::hover::hover_via_db;
 use super::lint::ServerRules;
-use super::project_navigation::{project_definition_via_db, project_hover_via_db};
+use super::project_navigation::{
+    project_definition_via_db, project_document_links_via_db, project_hover_via_db,
+};
 use super::pull_diagnostics::document_diagnostics_via_db;
 use super::references::{document_highlights_via_db, references_via_db};
 use super::rename::{prepare_rename_via_db, rename_via_db};
@@ -210,6 +212,14 @@ pub(crate) enum ReadJob {
         position: Position,
         sender: ReadReply,
     },
+    /// Document links in an open *project file*: each dependency name links to
+    /// its package's entry file, the same target
+    /// [`ProjectDefinition`](Self::ProjectDefinition) jumps to.
+    ProjectDocumentLinks {
+        id: RequestId,
+        text: Arc<TextBuffer>,
+        sender: ReadReply,
+    },
     References {
         id: RequestId,
         uri: Uri,
@@ -317,6 +327,7 @@ impl ReadJob {
             ReadJob::Definition { id, sender, .. } => (id, sender),
             ReadJob::ProjectDefinition { id, sender, .. } => (id, sender),
             ReadJob::ProjectHover { id, sender, .. } => (id, sender),
+            ReadJob::ProjectDocumentLinks { id, sender, .. } => (id, sender),
             ReadJob::References { id, sender, .. } => (id, sender),
             ReadJob::DocumentHighlight { id, sender, .. } => (id, sender),
             ReadJob::PrepareRename { id, sender, .. } => (id, sender),
@@ -564,6 +575,10 @@ pub(crate) fn run_read(snapshot: Analysis, job: ReadJob, encoding: PositionEncod
         } => {
             let hover = project_hover_via_db(&snapshot, &text, position, encoding);
             let _ = sender.send(Message::Response(Response::new_ok(id, hover)));
+        }
+        ReadJob::ProjectDocumentLinks { id, text, sender } => {
+            let links = project_document_links_via_db(&snapshot, &text, encoding);
+            let _ = sender.send(Message::Response(Response::new_ok(id, links)));
         }
         ReadJob::References {
             id,

--- a/src/lsp/read_jobs.rs
+++ b/src/lsp/read_jobs.rs
@@ -30,7 +30,7 @@ use super::folding::folding_ranges_via_db;
 use super::format::{format_edits_via_db, format_range_edits_via_db};
 use super::hover::hover_via_db;
 use super::lint::ServerRules;
-use super::project_navigation::project_definition_via_db;
+use super::project_navigation::{project_definition_via_db, project_hover_via_db};
 use super::pull_diagnostics::document_diagnostics_via_db;
 use super::references::{document_highlights_via_db, references_via_db};
 use super::rename::{prepare_rename_via_db, rename_via_db};
@@ -201,6 +201,15 @@ pub(crate) enum ReadJob {
         position: Position,
         sender: ReadReply,
     },
+    /// Hover in an open *project file*: a `[deps]` name reports the version,
+    /// kind, and resolved path the environment gave it. Pathless for the same
+    /// reason as [`ProjectDefinition`](Self::ProjectDefinition).
+    ProjectHover {
+        id: RequestId,
+        text: Arc<TextBuffer>,
+        position: Position,
+        sender: ReadReply,
+    },
     References {
         id: RequestId,
         uri: Uri,
@@ -307,6 +316,7 @@ impl ReadJob {
             ReadJob::SignatureHelp { id, sender, .. } => (id, sender),
             ReadJob::Definition { id, sender, .. } => (id, sender),
             ReadJob::ProjectDefinition { id, sender, .. } => (id, sender),
+            ReadJob::ProjectHover { id, sender, .. } => (id, sender),
             ReadJob::References { id, sender, .. } => (id, sender),
             ReadJob::DocumentHighlight { id, sender, .. } => (id, sender),
             ReadJob::PrepareRename { id, sender, .. } => (id, sender),
@@ -545,6 +555,15 @@ pub(crate) fn run_read(snapshot: Analysis, job: ReadJob, encoding: PositionEncod
                 id,
                 goto_response(locations),
             )));
+        }
+        ReadJob::ProjectHover {
+            id,
+            text,
+            position,
+            sender,
+        } => {
+            let hover = project_hover_via_db(&snapshot, &text, position, encoding);
+            let _ = sender.send(Message::Response(Response::new_ok(id, hover)));
         }
         ReadJob::References {
             id,

--- a/src/lsp/read_jobs.rs
+++ b/src/lsp/read_jobs.rs
@@ -31,8 +31,8 @@ use super::format::{format_edits_via_db, format_range_edits_via_db};
 use super::hover::hover_via_db;
 use super::lint::ServerRules;
 use super::project_navigation::{
-    project_definition_via_db, project_document_links_via_db, project_hover_via_db,
-    project_inlay_hints_via_db,
+    manifest_document_links, project_definition_via_db, project_document_links_via_db,
+    project_hover_via_db, project_inlay_hints_via_db,
 };
 use super::pull_diagnostics::document_diagnostics_via_db;
 use super::references::{document_highlights_via_db, references_via_db};
@@ -221,6 +221,16 @@ pub(crate) enum ReadJob {
         text: Arc<TextBuffer>,
         sender: ReadReply,
     },
+    /// Document links in an open *manifest*: each `path` entry links to the
+    /// `dev`'d package it pins. The one feature a manifest answers, and the one
+    /// project-file job that carries a `path`: the entry is a path itself, and
+    /// it resolves against the manifest's own directory.
+    ManifestDocumentLinks {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<TextBuffer>,
+        sender: ReadReply,
+    },
     /// Inlay hints in an open *project file*: each dependency's resolved
     /// version. `range` is the client's viewport, which it re-sends on every
     /// scroll, so hints outside it are never built.
@@ -338,6 +348,7 @@ impl ReadJob {
             ReadJob::ProjectDefinition { id, sender, .. } => (id, sender),
             ReadJob::ProjectHover { id, sender, .. } => (id, sender),
             ReadJob::ProjectDocumentLinks { id, sender, .. } => (id, sender),
+            ReadJob::ManifestDocumentLinks { id, sender, .. } => (id, sender),
             ReadJob::ProjectInlayHints { id, sender, .. } => (id, sender),
             ReadJob::References { id, sender, .. } => (id, sender),
             ReadJob::DocumentHighlight { id, sender, .. } => (id, sender),
@@ -589,6 +600,17 @@ pub(crate) fn run_read(snapshot: Analysis, job: ReadJob, encoding: PositionEncod
         }
         ReadJob::ProjectDocumentLinks { id, text, sender } => {
             let links = project_document_links_via_db(&snapshot, &text, encoding);
+            let _ = sender.send(Message::Response(Response::new_ok(id, links)));
+        }
+        // No snapshot in sight: a manifest's links are decided by its buffer
+        // and the filesystem, and its text never reaches the database.
+        ReadJob::ManifestDocumentLinks {
+            id,
+            path,
+            text,
+            sender,
+        } => {
+            let links = manifest_document_links(&text, &path, encoding);
             let _ = sender.send(Message::Response(Response::new_ok(id, links)));
         }
         ReadJob::ProjectInlayHints {

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -70,6 +70,7 @@ pub fn serve(connection: &Connection) -> Result<(), DynError> {
         supports_watched_files_registration(&params.capabilities) && !workspace_roots.is_empty();
     let pull_diagnostics = supports_pull_diagnostics(&params.capabilities);
     let diagnostic_refresh = supports_diagnostic_refresh(&params.capabilities);
+    let inlay_hint_refresh = supports_inlay_hint_refresh(&params.capabilities);
     let work_done_progress = supports_work_done_progress(&params.capabilities);
     let result =
         serde_json::json!({ "capabilities": capabilities_json(encoding, pull_diagnostics) });
@@ -81,6 +82,7 @@ pub fn serve(connection: &Connection) -> Result<(), DynError> {
         register_watchers,
         pull_diagnostics,
         diagnostic_refresh,
+        inlay_hint_refresh,
         work_done_progress,
         params.initialization_options,
     )
@@ -106,6 +108,21 @@ fn supports_diagnostic_refresh(capabilities: &ClientCapabilities) -> bool {
         .as_ref()
         .and_then(|workspace| workspace.diagnostic.as_ref())
         .and_then(|diagnostic| diagnostic.refresh_support)
+        .unwrap_or(false)
+}
+
+/// Whether the client accepts `workspace/inlayHint/refresh`, the server's nudge
+/// to re-request hints once the harvest supplies the versions they report.
+///
+/// Checked rather than assumed because the spec has this request force a
+/// *global* recalculation of every visible hint: a client that never claimed it
+/// should not be handed one.
+fn supports_inlay_hint_refresh(capabilities: &ClientCapabilities) -> bool {
+    capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.inlay_hint.as_ref())
+        .and_then(|inlay_hint| inlay_hint.refresh_support)
         .unwrap_or(false)
 }
 
@@ -331,6 +348,7 @@ fn main_loop(
     register_watchers: bool,
     pull_diagnostics: bool,
     diagnostic_refresh: bool,
+    inlay_hint_refresh: bool,
     work_done_progress: bool,
     initialization_options: Option<serde_json::Value>,
 ) -> Result<(), DynError> {
@@ -398,6 +416,7 @@ fn main_loop(
         encoding,
         pull_diagnostics,
         diagnostic_refresh,
+        inlay_hint_refresh,
         initialization_options,
     );
 
@@ -954,6 +973,21 @@ mod tests {
             ..Default::default()
         };
         assert!(supports_diagnostic_refresh(&caps));
+    }
+
+    #[test]
+    fn inlay_hint_refresh_requires_the_client_capability() {
+        assert!(!supports_inlay_hint_refresh(&ClientCapabilities::default()));
+        let caps = ClientCapabilities {
+            workspace: Some(lsp_types::WorkspaceClientCapabilities {
+                inlay_hint: Some(lsp_types::InlayHintWorkspaceClientCapabilities {
+                    refresh_support: Some(true),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(supports_inlay_hint_refresh(&caps));
     }
 
     #[test]

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -29,7 +29,9 @@ use crate::index::{
 };
 use crate::text::PositionEncoding;
 
-use super::analysis_thread::{AnalysisRequest, LibraryMessage, guard, spawn_analysis_thread};
+use super::analysis_thread::{
+    AnalysisRequest, LibraryMessage, SyncMessage, guard, spawn_analysis_thread,
+};
 use super::environment_diagnostics::{
     EnvironmentFindings, environment_diagnostics, resolve_failure_diagnostics,
 };
@@ -332,7 +334,7 @@ fn main_loop(
     // path, whose tracked input is reverted to on-disk text (a closed
     // document's discarded buffer, or a watched file changed outside any open
     // buffer).
-    let (sync_tx, sync_rx) = crossbeam_channel::unbounded::<PathBuf>();
+    let (sync_tx, sync_rx) = crossbeam_channel::unbounded::<SyncMessage>();
 
     // Resolve the environment and harvest its packages off the event loop: it
     // walks the filesystem and parses all of Base, so it must not block the

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -12,12 +12,12 @@ use lsp_types::{
     CodeActionProviderCapability, CompletionOptions, DiagnosticOptions,
     DiagnosticServerCapabilities, DocumentLinkOptions, FileOperationFilter, FileOperationPattern,
     FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, InitializeParams, OneOf, PositionEncodingKind, RenameOptions,
-    SelectionRangeProviderCapability, SemanticTokensFullOptions, SemanticTokensOptions,
-    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, Uri,
-    WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
-    WorkspaceServerCapabilities,
+    HoverProviderCapability, InitializeParams, InlayHintOptions, InlayHintServerCapabilities,
+    OneOf, PositionEncodingKind, RenameOptions, SelectionRangeProviderCapability,
+    SemanticTokensFullOptions, SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, Uri, WorkspaceFileOperationsServerCapabilities,
+    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
 };
 
 use std::sync::Arc;
@@ -241,6 +241,18 @@ fn server_capabilities(encoding: PositionEncoding, pull_diagnostics: bool) -> Se
             resolve_provider: Some(false),
             work_done_progress_options: Default::default(),
         }),
+        // Project files only: a dependency's resolved version, beside its UUID.
+        // Julia documents answer an empty list — inlay *type* hints would need
+        // inference, and fatou runs no Julia. Advertised globally all the same,
+        // as every other per-kind capability here is.
+        inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
+            InlayHintOptions {
+                // Label and tooltip are both built up front from the library
+                // map already in memory, so there is nothing to defer.
+                resolve_provider: Some(false),
+                work_done_progress_options: Default::default(),
+            },
+        ))),
         selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
         semantic_tokens_provider: Some(
             SemanticTokensOptions {
@@ -746,6 +758,18 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    /// Advertised globally, like every other per-kind capability here, and with
+    /// no resolve step: the label and tooltip are both built from the library
+    /// map already in memory.
+    #[test]
+    fn advertises_inlay_hints_without_a_resolve_step() {
+        let caps = capabilities_json(PositionEncoding::Utf16, false);
+        assert_eq!(
+            caps["inlayHintProvider"]["resolveProvider"],
+            serde_json::json!(false)
+        );
     }
 
     #[test]

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -1184,7 +1184,7 @@ impl GlobalState {
                 let version = self.documents.get(&uri).map(|d| d.version);
                 self.publish_merged(uri, version);
             }
-            Outbound::DiagnosticsRefresh => self.send_diagnostic_refresh(),
+            Outbound::DiagnosticsRefresh => self.refresh_open_diagnostics(),
             Outbound::ReadReply { message } => self.on_read_reply(message),
         }
     }
@@ -1314,15 +1314,35 @@ impl GlobalState {
     }
 
     /// Re-derive the open documents' diagnostics after a configuration change
-    /// (editor-pushed settings, or a `fatou.toml` event). A pull client is
-    /// nudged to re-pull (each pull resolves config afresh); a push client
-    /// gets a re-analysis per open document — same version, new rules — which
-    /// the analysis thread's coalescing absorbs.
+    /// (editor-pushed settings, or a `fatou.toml` event).
     fn on_config_changed(&mut self) {
+        self.refresh_open_diagnostics();
+    }
+
+    /// Re-derive the open documents' diagnostics, whatever moved underneath
+    /// them: a configuration change, a re-harvest, or a project-file edit that
+    /// changed the package's declared dependencies. A pull client is nudged to
+    /// re-pull (each pull resolves config and reads the db afresh); a push
+    /// client gets a re-analysis per open document — same version, new
+    /// premises — which the analysis thread's coalescing absorbs.
+    ///
+    /// A push client needs the second branch for the same reason a pull client
+    /// needs the first: `unresolved-import` and `undefined-name` answer to the
+    /// library and the declared deps, not to the buffer, so nothing else would
+    /// ever revisit them for a document the user is not typing in.
+    fn refresh_open_diagnostics(&mut self) {
         if self.pull_diagnostics {
             self.send_diagnostic_refresh();
         } else {
-            let uris: Vec<Uri> = self.documents.keys().cloned().collect();
+            // Environment files are skipped: they publish no analysis, and
+            // re-sending an unchanged project buffer through `send_analysis`
+            // would only write it back to the db it just came from.
+            let uris: Vec<Uri> = self
+                .documents
+                .keys()
+                .filter(|uri| uri::to_path(uri).is_none_or(|path| !is_environment_file(&path)))
+                .cloned()
+                .collect();
             for uri in uris {
                 self.send_analysis(uri, None);
             }
@@ -1920,6 +1940,30 @@ mod tests {
             message: message.to_string(),
             ..Default::default()
         }
+    }
+
+    /// A refresh nudge reaches a *push* client too. It has no
+    /// `workspace/diagnostic/refresh` to answer, so the open documents are
+    /// re-analyzed instead — otherwise `unresolved-import` would keep answering
+    /// to premises that have since moved, in every file the user is not typing
+    /// in. The project file itself is skipped: it publishes no analysis.
+    #[test]
+    fn a_refresh_reanalyzes_a_push_clients_open_documents() {
+        let (mut state, channels) = test_state_with_channels();
+        let source = uri("file:///work/src/a.jl");
+        let project = uri("file:///work/Project.toml");
+        assert!(!state.pull_diagnostics, "this client pushes");
+        open(&mut state, &source, 3);
+        open(&mut state, &project, 1);
+
+        state.on_outbound(Outbound::DiagnosticsRefresh);
+
+        let requested: Vec<Uri> = channels.analysis.try_iter().map(|req| req.uri).collect();
+        assert_eq!(requested, vec![source]);
+        assert!(
+            channels.sync.try_recv().is_err(),
+            "and the project buffer is not written back to the db it came from"
+        );
     }
 
     /// A `publishDiagnostics` replaces *all* diagnostics for a URI, so the

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -17,11 +17,11 @@ use lsp_types::request::{
     CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
     CodeActionRequest, Completion, DocumentDiagnosticRequest, DocumentHighlightRequest,
     DocumentLinkRequest, DocumentSymbolRequest, FoldingRangeRequest, Formatting, GotoDefinition,
-    HoverRequest, PrepareRenameRequest, RangeFormatting, References, RegisterCapability, Rename,
-    Request as RequestTrait, ResolveCompletionItem, SelectionRangeRequest,
-    SemanticTokensFullDeltaRequest, SemanticTokensFullRequest, SignatureHelpRequest,
-    TypeHierarchyPrepare, TypeHierarchySubtypes, TypeHierarchySupertypes, WillRenameFiles,
-    WorkspaceDiagnosticRefresh, WorkspaceSymbolRequest,
+    HoverRequest, InlayHintRequest, PrepareRenameRequest, RangeFormatting, References,
+    RegisterCapability, Rename, Request as RequestTrait, ResolveCompletionItem,
+    SelectionRangeRequest, SemanticTokensFullDeltaRequest, SemanticTokensFullRequest,
+    SignatureHelpRequest, TypeHierarchyPrepare, TypeHierarchySubtypes, TypeHierarchySupertypes,
+    WillRenameFiles, WorkspaceDiagnosticRefresh, WorkspaceSymbolRequest,
 };
 use lsp_types::{
     CallHierarchyIncomingCallsParams, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
@@ -31,11 +31,12 @@ use lsp_types::{
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
     DocumentFormattingParams, DocumentHighlightParams, DocumentLinkParams,
     DocumentRangeFormattingParams, DocumentSymbolParams, FileSystemWatcher, FoldingRangeParams,
-    GlobPattern, GotoDefinitionParams, HoverParams, LogMessageParams, MessageType, NumberOrString,
-    PublishDiagnosticsParams, ReferenceParams, Registration, RegistrationParams, RenameFilesParams,
-    RenameParams, SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensParams,
-    SignatureHelpParams, TextDocumentPositionParams, TypeHierarchyPrepareParams,
-    TypeHierarchySubtypesParams, TypeHierarchySupertypesParams, Uri, WorkspaceSymbolParams,
+    GlobPattern, GotoDefinitionParams, HoverParams, InlayHintParams, LogMessageParams, MessageType,
+    NumberOrString, PublishDiagnosticsParams, ReferenceParams, Registration, RegistrationParams,
+    RenameFilesParams, RenameParams, SelectionRangeParams, SemanticTokensDeltaParams,
+    SemanticTokensParams, SignatureHelpParams, TextDocumentPositionParams,
+    TypeHierarchyPrepareParams, TypeHierarchySubtypesParams, TypeHierarchySupertypesParams, Uri,
+    WorkspaceSymbolParams,
 };
 
 use crate::config::CONFIG_FILE_NAME;
@@ -266,6 +267,7 @@ impl GlobalState {
             WorkspaceSymbolRequest::METHOD => self.on_workspace_symbols(req),
             FoldingRangeRequest::METHOD => self.on_folding_ranges(req),
             DocumentLinkRequest::METHOD => self.on_document_links(req),
+            InlayHintRequest::METHOD => self.on_inlay_hints(req),
             SelectionRangeRequest::METHOD => self.on_selection_ranges(req),
             SemanticTokensFullRequest::METHOD => self.on_semantic_tokens_full(req),
             SemanticTokensFullDeltaRequest::METHOD => self.on_semantic_tokens_full_delta(req),
@@ -486,6 +488,30 @@ impl GlobalState {
             id,
             path: path_for(&uri),
             text,
+            sender: reply,
+        });
+    }
+
+    /// Inlay hints are a project file's alone: a dependency's resolved version
+    /// beside its UUID. A Julia document answers an empty list rather than
+    /// `null` — the capability is advertised globally, and an empty list is the
+    /// honest answer to "what hints does this file have".
+    fn on_inlay_hints(&mut self, req: Request) {
+        let id = req.id.clone();
+        let Ok((_, params)) = req.extract::<InlayHintParams>(InlayHintRequest::METHOD) else {
+            self.respond_err(id, "invalid inlayHint params");
+            return;
+        };
+        let uri = params.text_document.uri;
+        let Some(text) = self.project_text(&uri) else {
+            self.respond_ok(id, serde_json::json!([]));
+            return;
+        };
+        let reply = self.read_reply(id.clone(), Some(&uri));
+        self.dispatch_read(ReadJob::ProjectInlayHints {
+            id,
+            text,
+            range: params.range,
             sender: reply,
         });
     }
@@ -2480,6 +2506,59 @@ mod tests {
             other => panic!("expected a response, got {other:?}"),
         }
         assert!(channels.read.try_recv().is_err(), "and no read job");
+    }
+
+    /// Inlay hints are a project file's alone, but unlike the other three a
+    /// Julia document answers an **empty list** rather than `null`: the
+    /// capability is advertised globally, and "this file has no hints" is the
+    /// honest answer, not "I do not do hints".
+    #[test]
+    fn inlay_hints_answer_empty_for_a_julia_document() {
+        let (mut state, channels) = test_state_with_channels();
+        let source = uri("file:///work/a.jl");
+        did_open(&mut state, &source, "x = 1\n");
+        // Drain the analysis the open dispatched.
+        let _ = channels.analysis.try_recv();
+
+        state.on_request(inlay_hint_request(1, &source));
+
+        match channels.client.try_recv().expect("a response") {
+            Message::Response(resp) => {
+                assert_eq!(resp.response_result.ok(), Some(serde_json::json!([])));
+            }
+            other => panic!("expected a response, got {other:?}"),
+        }
+        assert!(channels.read.try_recv().is_err(), "and no read job");
+    }
+
+    #[test]
+    fn a_project_buffer_reaches_the_read_pool_for_inlay_hints() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+        did_open(&mut state, &project, "[deps]\nA = \"x\"\n");
+
+        state.on_request(inlay_hint_request(1, &project));
+
+        match channels.read.try_recv().expect("a read job") {
+            ReadJob::ProjectInlayHints { id, range, .. } => {
+                assert_eq!(id, RequestId::from(1));
+                assert_eq!(range.end, Position::new(2, 0));
+            }
+            _ => panic!("expected a ProjectInlayHints read job"),
+        }
+    }
+
+    /// A `textDocument/inlayHint` over the first two lines of `uri`.
+    fn inlay_hint_request(id: i32, uri: &Uri) -> Request {
+        Request::new(
+            RequestId::from(id),
+            InlayHintRequest::METHOD.to_string(),
+            InlayHintParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                range: lsp_types::Range::new(Position::new(0, 0), Position::new(2, 0)),
+                work_done_progress_params: Default::default(),
+            },
+        )
     }
 
     /// A `textDocument/definition` at line 1, column 0 of `uri`.

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -574,6 +574,19 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        // A project file reports what a dependency name resolved to; a Julia
+        // document reports a symbol. Anything else answers `null`.
+        if let Some(text) = self.project_text(&uri) {
+            let reply = self.read_reply(id.clone(), Some(&uri));
+            self.dispatch_read(ReadJob::ProjectHover {
+                id,
+                text,
+                position,
+                sender: reply,
+            });
+            return;
+        }
         let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
@@ -583,7 +596,7 @@ impl GlobalState {
             id,
             path: path_for(&uri),
             text,
-            position: params.text_document_position_params.position,
+            position,
             sender: reply,
         });
     }

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -76,17 +76,40 @@ enum DocumentKind {
     /// `path` entries — the one feature needing no environment resolve, which
     /// is otherwise the harvester's job and never reads a buffer.
     Manifest,
+    /// A TOML file that is neither: a `fatou.toml`, a `Manifest-vfoo.toml` that
+    /// names no version, a `Project.toml` flavor this server does not know.
+    ///
+    /// It answers **nothing** — no analysis, no diagnostics, no read job, no
+    /// text in the database. The point is that the server's behavior stops
+    /// depending on how wide the client's document selector happens to be: a
+    /// selector matching one `.toml` too many costs a document the server
+    /// ignores, never a TOML file parsed as Julia.
+    Other,
 }
 
 impl DocumentKind {
-    /// A document's kind, from the file its URI names. A URI with no path
-    /// behind it — an editor's untitled buffer — is Julia: it is what the
-    /// editor opened the server for, and it has no file name to say otherwise.
+    /// A document's kind, from the file its URI names.
+    ///
+    /// A URI with no path behind it — an editor's untitled buffer — is Julia:
+    /// it is what the editor opened the server for, and it has no file name to
+    /// say otherwise. Everything else is Julia unless its name says it is not,
+    /// and **a `.toml` always says it is not**: the two environment flavors get
+    /// their own routes and the rest answer nothing, rather than the recognized
+    /// flavors being carved out of a Julia default. The client's selector
+    /// carries `**/Manifest-v*.toml` while [`is_manifest_file`] wants a version
+    /// it can parse, and that gap must not land in the Julia parser.
     fn of(uri: &Uri) -> Self {
-        match uri::to_path(uri) {
-            Some(path) if is_project_file(&path) => Self::Project,
-            Some(path) if is_manifest_file(&path) => Self::Manifest,
-            _ => Self::Julia,
+        let Some(path) = uri::to_path(uri) else {
+            return Self::Julia;
+        };
+        if is_project_file(&path) {
+            Self::Project
+        } else if is_manifest_file(&path) {
+            Self::Manifest
+        } else if path.extension().is_some_and(|ext| ext == "toml") {
+            Self::Other
+        } else {
+            Self::Julia
         }
     }
 }
@@ -1481,13 +1504,14 @@ impl GlobalState {
     /// the package's declared dependencies from it — that is what lets an
     /// unsaved `[deps]` edit reach `unresolved-import` across the package. A
     /// manifest sends no text: nothing reads one without an environment
-    /// resolve, which is the harvester's job.
+    /// resolve, which is the harvester's job. A TOML file that is neither is
+    /// not this server's to describe, and takes no route at all.
     ///
     /// `edits` belong to the Julia route alone (see
     /// [`send_analysis`](Self::send_analysis)).
     fn route_document(&mut self, uri: Uri, edits: Option<Vec<Edit>>) {
         match self.documents.get(&uri).map(|doc| doc.kind) {
-            None => {}
+            None | Some(DocumentKind::Other) => {}
             Some(DocumentKind::Julia) => self.send_analysis(uri, edits),
             Some(kind) => {
                 if kind == DocumentKind::Project {
@@ -2778,5 +2802,43 @@ mod tests {
             DocumentKind::of(&uri("file:///work/src/a.jl")),
             DocumentKind::Julia
         );
+    }
+
+    /// A `.toml` is never Julia. The client's selector carries
+    /// `**/Manifest-v*.toml` and `is_manifest_file` wants a version it can
+    /// parse, so the two do not meet exactly — and the gap must land in a
+    /// document that answers nothing, never in the Julia parser.
+    #[test]
+    fn an_unrecognized_toml_is_neither_julia_nor_an_environment_file() {
+        for name in [
+            "Manifest-vfoo.toml",
+            "Manifest-v.toml",
+            "fatou.toml",
+            "Cargo.toml",
+        ] {
+            assert_eq!(
+                DocumentKind::of(&uri(&format!("file:///work/{name}"))),
+                DocumentKind::Other,
+                "for {name}"
+            );
+        }
+    }
+
+    /// And it takes no route: no Julia analysis (which is the bug — a TOML file
+    /// reported as broken Julia), no text into the database, and no diagnostics
+    /// of its own, since the server has nothing to say about the file.
+    #[test]
+    fn an_unrecognized_toml_takes_no_route() {
+        let (mut state, channels) = test_state_with_channels();
+
+        did_open(
+            &mut state,
+            &uri("file:///work/Manifest-vfoo.toml"),
+            "[[deps\n",
+        );
+
+        assert!(channels.analysis.try_recv().is_err(), "no Julia analysis");
+        assert!(channels.sync.try_recv().is_err(), "nothing reaches the db");
+        assert!(channels.client.try_recv().is_err(), "and nothing published");
     }
 }

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -17,8 +17,8 @@ use lsp_types::request::{
     CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls, CallHierarchyPrepare,
     CodeActionRequest, Completion, DocumentDiagnosticRequest, DocumentHighlightRequest,
     DocumentLinkRequest, DocumentSymbolRequest, FoldingRangeRequest, Formatting, GotoDefinition,
-    HoverRequest, InlayHintRequest, PrepareRenameRequest, RangeFormatting, References,
-    RegisterCapability, Rename, Request as RequestTrait, ResolveCompletionItem,
+    HoverRequest, InlayHintRefreshRequest, InlayHintRequest, PrepareRenameRequest, RangeFormatting,
+    References, RegisterCapability, Rename, Request as RequestTrait, ResolveCompletionItem,
     SelectionRangeRequest, SemanticTokensFullDeltaRequest, SemanticTokensFullRequest,
     SignatureHelpRequest, TypeHierarchyPrepare, TypeHierarchySubtypes, TypeHierarchySupertypes,
     WillRenameFiles, WorkspaceDiagnosticRefresh, WorkspaceSymbolRequest,
@@ -128,6 +128,17 @@ pub(crate) enum Outbound {
     /// per harvest; the main loop forwards it only when the client supports
     /// both pull diagnostics and the refresh request.
     DiagnosticsRefresh,
+    /// The harvested library landed, so what an open `Project.toml`'s inlay
+    /// hints report — each dependency's resolved version — exists for the first
+    /// time. Unlike a diagnostic, a hint has no push channel and a client
+    /// re-requests one only on an edit or a scroll, so a file already open at
+    /// startup would otherwise sit blank until the user touched it.
+    ///
+    /// Its own signal rather than a share of [`DiagnosticsRefresh`]: that one
+    /// also fires on a project-file keystroke, and hints are re-requested on an
+    /// edit anyway. The spec has this request force a *global* recalculation,
+    /// which is worth spending once per harvest and not once per keystroke.
+    InlayHintsRefresh,
     /// A finished read job (hover, format, …). The worker routes its response
     /// here instead of straight to the client so the main loop can version-gate
     /// it against the buffer the read was dispatched on (stale → `ContentModified`)
@@ -188,6 +199,11 @@ pub(crate) struct GlobalState {
     /// Whether the client accepts `workspace/diagnostic/refresh`, the nudge to
     /// re-pull after a re-harvest changes the include graph.
     diagnostic_refresh: bool,
+    /// Whether the client accepts `workspace/inlayHint/refresh`, the nudge to
+    /// re-request hints once the harvest lands. Unlike a diagnostic, a hint has
+    /// no push channel: without this an open `Project.toml` shows no version
+    /// beside a UUID until the user happens to edit or scroll it.
+    inlay_hint_refresh: bool,
     /// Sequence number for server-to-client refresh requests, so each carries
     /// a fresh JSON-RPC id.
     refresh_seq: u64,
@@ -232,6 +248,7 @@ impl GlobalState {
         encoding: PositionEncoding,
         pull_diagnostics: bool,
         diagnostic_refresh: bool,
+        inlay_hint_refresh: bool,
         initialization_options: Option<serde_json::Value>,
     ) -> Self {
         let (config, warnings) = ConfigStore::new(initialization_options);
@@ -251,6 +268,7 @@ impl GlobalState {
             encoding,
             pull_diagnostics,
             diagnostic_refresh,
+            inlay_hint_refresh,
             refresh_seq: 0,
             config,
         };
@@ -1363,6 +1381,7 @@ impl GlobalState {
                 self.publish_merged(uri, version);
             }
             Outbound::DiagnosticsRefresh => self.refresh_open_diagnostics(),
+            Outbound::InlayHintsRefresh => self.send_inlay_hint_refresh(),
             Outbound::ReadReply { message } => self.on_read_reply(message),
         }
     }
@@ -1603,6 +1622,25 @@ impl GlobalState {
         }));
     }
 
+    /// Ask the client to re-request inlay hints (`workspace/inlayHint/refresh`);
+    /// a no-op without the client capability.
+    ///
+    /// Sent once per full harvest, which is when `package_meta` — the whole of
+    /// what a hint reports — comes into existence. Nothing else recomputes a
+    /// hint for a file the user is not typing in, so without this an open
+    /// `Project.toml` shows a bare UUID for the rest of the session.
+    fn send_inlay_hint_refresh(&mut self) {
+        if !self.inlay_hint_refresh {
+            return;
+        }
+        self.refresh_seq += 1;
+        let _ = self.sender.send(Message::Request(Request {
+            id: RequestId::from(format!("fatou-inlay-hint-refresh-{}", self.refresh_seq)),
+            method: InlayHintRefreshRequest::METHOD.to_string(),
+            params: serde_json::Value::Null,
+        }));
+    }
+
     fn log_warnings(&self, warnings: Vec<String>) {
         for warning in warnings {
             self.log_message(MessageType::WARNING, warning);
@@ -1702,6 +1740,7 @@ mod tests {
             harvest_tx,
             sync_tx,
             PositionEncoding::Utf16,
+            false,
             false,
             false,
             None,
@@ -2658,6 +2697,35 @@ mod tests {
             }
             _ => panic!("expected a ProjectInlayHints read job"),
         }
+    }
+
+    /// The library map arrives with the harvest, seconds after `initialize`,
+    /// and it is the whole of what a `[deps]` hint reports. A client
+    /// re-requests hints only on an edit or a scroll, so without the nudge a
+    /// `Project.toml` opened at startup shows a bare UUID for the session.
+    #[test]
+    fn a_landed_harvest_asks_the_client_to_re_request_hints() {
+        let (mut state, channels) = test_state_with_channels();
+        state.inlay_hint_refresh = true;
+
+        state.on_outbound(Outbound::InlayHintsRefresh);
+
+        match channels.client.try_recv().expect("a request") {
+            Message::Request(req) => assert_eq!(req.method, InlayHintRefreshRequest::METHOD),
+            other => panic!("expected a request, got {other:?}"),
+        }
+    }
+
+    /// The spec has the request force a *global* recalculation of every visible
+    /// hint, so a client that never claimed the capability is not handed one.
+    #[test]
+    fn an_inlay_hint_refresh_needs_the_client_capability() {
+        let (mut state, channels) = test_state_with_channels();
+        assert!(!state.inlay_hint_refresh, "the default test client");
+
+        state.on_outbound(Outbound::InlayHintsRefresh);
+
+        assert!(channels.client.try_recv().is_err());
     }
 
     /// A `textDocument/inlayHint` over the first two lines of `uri`.

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -39,11 +39,11 @@ use lsp_types::{
 };
 
 use crate::config::CONFIG_FILE_NAME;
-use crate::environment::is_environment_file;
+use crate::environment::{is_environment_file, is_project_file};
 use crate::parser::Edit;
 use crate::text::{PositionEncoding, TextBuffer, apply_content_changes};
 
-use super::analysis_thread::AnalysisRequest;
+use super::analysis_thread::{AnalysisRequest, SyncMessage};
 use super::config::{ConfigStore, ResolvedConfig};
 use super::read_jobs::{ReadJob, ReadReply};
 use super::server::HarvestSignal;
@@ -130,12 +130,13 @@ pub(crate) struct GlobalState {
     /// path (it re-harvests the workspace package owning the file) or an
     /// environment-file change (it re-resolves every workspace environment).
     harvest_tx: Sender<HarvestSignal>,
-    /// Disk-sync signals to the analysis thread: a file's path, whose tracked
-    /// input is reverted to on-disk text. Sent when a document closes (a
-    /// discarded buffer must not linger in the reverse-occurrence index) and
-    /// when a watched file changes outside any open buffer (the stale seeded
-    /// text must catch up with disk).
-    sync_tx: Sender<PathBuf>,
+    /// Text writes to the analysis thread for files the analysis pipeline does
+    /// not own: a revert to on-disk text when a document closes (a discarded
+    /// buffer must not linger in the reverse-occurrence index) or when a
+    /// watched file changes outside any open buffer (the stale seeded text must
+    /// catch up with disk), and an open project file's buffer, which is not
+    /// Julia but whose `[deps]` the linter reads.
+    sync_tx: Sender<SyncMessage>,
     /// The position encoding negotiated at initialize, fixed for the session.
     encoding: PositionEncoding,
     /// Whether the client pulls diagnostics (`textDocument/diagnostic`). When
@@ -180,7 +181,7 @@ impl GlobalState {
         analysis_tx: Sender<AnalysisRequest>,
         read_tx: Sender<ReadJob>,
         harvest_tx: Sender<HarvestSignal>,
-        sync_tx: Sender<PathBuf>,
+        sync_tx: Sender<SyncMessage>,
         encoding: PositionEncoding,
         pull_diagnostics: bool,
         diagnostic_refresh: bool,
@@ -967,7 +968,7 @@ impl GlobalState {
                     // buffer's (possibly unsaved) edits must not linger in the
                     // reverse-occurrence index. A dead channel is a no-op.
                     if let Some(path) = uri::to_path(&uri) {
-                        let _ = self.sync_tx.send(path);
+                        let _ = self.sync_tx.send(SyncMessage::Revert(path));
                     }
                     // Drop the buffer's parse diagnostics, but keep any project-
                     // level include-graph diagnostics (they attach to the file on
@@ -1018,7 +1019,7 @@ impl GlobalState {
                 continue;
             }
             if !self.documents.contains_key(&event.uri) {
-                let _ = self.sync_tx.send(path.clone());
+                let _ = self.sync_tx.send(SyncMessage::Revert(path.clone()));
             }
             if !environment_changed {
                 let _ = self.harvest_tx.send(HarvestSignal::Source(path));
@@ -1078,7 +1079,7 @@ impl GlobalState {
             // The moved-from path is gone and the moved-to one is not tracked
             // yet; both sync as no-ops until the re-harvest settles membership.
             if uri::from_path(&path).is_none_or(|uri| !self.documents.contains_key(&uri)) {
-                let _ = self.sync_tx.send(path.clone());
+                let _ = self.sync_tx.send(SyncMessage::Revert(path.clone()));
             }
             if !environment_changed {
                 let _ = self.harvest_tx.send(HarvestSignal::Source(path));
@@ -1272,8 +1273,22 @@ impl GlobalState {
     /// only never analyzed. Guarded here rather than at the `didOpen` call
     /// site so `didChange` and [`on_config_changed`](Self::on_config_changed)
     /// are covered by the same return.
+    ///
+    /// A *project* file takes the other fork instead: its text goes to the db
+    /// as text, because the linter derives the package's declared dependencies
+    /// from it. That is what lets an unsaved `[deps]` edit reach
+    /// `unresolved-import` across the package. A manifest takes neither fork —
+    /// nothing reads it without a resolve, which is the harvester's job.
     fn send_analysis(&mut self, uri: Uri, edits: Option<Vec<Edit>>) {
-        if uri::to_path(&uri).is_some_and(|path| is_environment_file(&path)) {
+        if let Some(path) = uri::to_path(&uri).filter(|path| is_environment_file(path)) {
+            if is_project_file(&path)
+                && let Some(doc) = self.documents.get(&uri)
+            {
+                let _ = self.sync_tx.send(SyncMessage::SetText {
+                    path,
+                    text: doc.text.text().to_string(),
+                });
+            }
             return;
         }
         let rules = Arc::clone(&self.config_for(&uri).rules);
@@ -1408,7 +1423,7 @@ mod tests {
         analysis: Receiver<AnalysisRequest>,
         read: Receiver<ReadJob>,
         harvest: Receiver<HarvestSignal>,
-        sync: Receiver<PathBuf>,
+        sync: Receiver<SyncMessage>,
     }
 
     /// [`test_state`], keeping every auxiliary receiver alive.
@@ -1447,6 +1462,18 @@ mod tests {
 
     fn uri(path: &str) -> Uri {
         Uri::from_str(path).unwrap()
+    }
+
+    /// The paths a batch of sync messages reverts to disk, in order.
+    fn reverted(sync: &Receiver<SyncMessage>) -> Vec<PathBuf> {
+        sync.try_iter()
+            .map(|msg| match msg {
+                SyncMessage::Revert(path) => path,
+                SyncMessage::SetText { path, .. } => {
+                    panic!("expected a revert, got a text write for {}", path.display())
+                }
+            })
+            .collect()
     }
 
     fn open(state: &mut GlobalState, uri: &Uri, version: i32) {
@@ -1689,8 +1716,10 @@ mod tests {
             files: vec![lsp_types::FileRename { old_uri, new_uri }],
         });
 
-        let synced: Vec<PathBuf> = channels.sync.try_iter().collect();
-        assert_eq!(synced, vec![old_path.clone(), new_path.clone()]);
+        assert_eq!(
+            reverted(&channels.sync),
+            vec![old_path.clone(), new_path.clone()]
+        );
         let signals: Vec<HarvestSignal> = channels.harvest.try_iter().collect();
         assert_eq!(
             signals,
@@ -1811,6 +1840,65 @@ mod tests {
             channels.analysis.try_recv().is_ok(),
             "a Julia buffer analyzes as before"
         );
+        assert!(
+            channels.sync.try_recv().is_err(),
+            "a Julia buffer reaches the db through the analysis pipeline, not the sync channel"
+        );
+    }
+
+    /// An open project file's buffer reaches the database as *text*: the linter
+    /// derives the package's declared dependencies from it, so an unsaved
+    /// `[deps]` edit must count before any save.
+    #[test]
+    fn a_project_file_buffer_is_written_to_the_database() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+
+        did_open(&mut state, &project, "[deps]\n");
+        let opened = channels
+            .sync
+            .try_recv()
+            .expect("the open buffer is written");
+        assert!(
+            matches!(&opened, SyncMessage::SetText { text, .. } if text == "[deps]\n"),
+            "didOpen sends the buffer text"
+        );
+
+        state.on_notification(Notification::new(
+            DidChangeTextDocument::METHOD.to_string(),
+            DidChangeTextDocumentParams {
+                text_document: lsp_types::VersionedTextDocumentIdentifier {
+                    uri: project,
+                    version: 2,
+                },
+                content_changes: vec![lsp_types::TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "[deps]\nFoo = \"x\"\n".to_string(),
+                }],
+            },
+        ));
+        let changed = channels.sync.try_recv().expect("the edit is written");
+        assert!(
+            matches!(&changed, SyncMessage::SetText { text, .. } if text.contains("Foo")),
+            "didChange sends the edited buffer text"
+        );
+        assert!(
+            channels.analysis.try_recv().is_err(),
+            "and still never as a Julia analysis"
+        );
+    }
+
+    /// A manifest takes neither fork: nothing reads it without an environment
+    /// resolve, which is the harvester's job and reads disk.
+    #[test]
+    fn a_manifest_buffer_is_not_written_to_the_database() {
+        let (mut state, channels) = test_state_with_channels();
+
+        did_open(&mut state, &uri("file:///work/Manifest.toml"), "[deps]\n");
+
+        assert!(channels.sync.try_recv().is_err());
+        assert!(channels.analysis.try_recv().is_err());
     }
 
     /// The diagnostics published for `uri`, from the next `publishDiagnostics`

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -466,6 +466,17 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
+        // A project file links each dependency name to its package; a Julia
+        // document links each static `include`. Anything else answers `null`.
+        if let Some(text) = self.project_text(&uri) {
+            let reply = self.read_reply(id.clone(), Some(&uri));
+            self.dispatch_read(ReadJob::ProjectDocumentLinks {
+                id,
+                text,
+                sender: reply,
+            });
+            return;
+        }
         let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -65,15 +65,16 @@ struct Document {
 /// its own ([`GlobalState::route_document`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DocumentKind {
-    /// Julia source: the analysis pipeline's business, and the only kind any
-    /// language feature answers for.
+    /// Julia source: the analysis pipeline's business, and the kind nearly
+    /// every language feature answers for.
     Julia,
     /// A `Project.toml` flavor. Its text reaches the database, because the
     /// linter derives the package's declared dependencies from it; its buffer
     /// also carries the file's own TOML diagnostics.
     Project,
-    /// A `Manifest.toml` flavor. Diagnostics only: nothing reads a manifest
-    /// without an environment resolve, which is the harvester's job.
+    /// A `Manifest.toml` flavor. Diagnostics, plus the document links on its
+    /// `path` entries — the one feature needing no environment resolve, which
+    /// is otherwise the harvester's job and never reads a buffer.
     Manifest,
 }
 
@@ -468,12 +469,23 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        // A project file links each dependency name to its package; a Julia
-        // document links each static `include`. Anything else answers `null`.
+        // A project file links each dependency name to its package, a manifest
+        // each `path` entry to the package it pins, and a Julia document each
+        // static `include`. Anything else answers `null`.
         if let Some(text) = self.project_text(&uri) {
             let reply = self.read_reply(id.clone(), Some(&uri));
             self.dispatch_read(ReadJob::ProjectDocumentLinks {
                 id,
+                text,
+                sender: reply,
+            });
+            return;
+        }
+        if let Some(text) = self.manifest_text(&uri) {
+            let reply = self.read_reply(id.clone(), Some(&uri));
+            self.dispatch_read(ReadJob::ManifestDocumentLinks {
+                id,
+                path: path_for(&uri),
                 text,
                 sender: reply,
             });
@@ -966,14 +978,26 @@ impl GlobalState {
     /// everything Julia-backed keeps asking there, and a handler that calls
     /// neither still answers `null` as before.
     ///
-    /// A `Manifest.toml` deliberately answers nothing. Its text never reaches
-    /// the database (nothing reads a manifest without an environment resolve),
-    /// and its entries carry no spans to anchor on — see
-    /// [`project_navigation`](super::project_navigation).
+    /// A `Manifest.toml` answers nothing here. Its text never reaches the
+    /// database (nothing reads a manifest without an environment resolve), so
+    /// every feature that consults one stops at this door; the single feature
+    /// that does not asks [`manifest_text`](Self::manifest_text).
     fn project_text(&self, uri: &Uri) -> Option<Arc<TextBuffer>> {
         self.documents
             .get(uri)
             .filter(|doc| doc.kind == DocumentKind::Project)
+            .map(|doc| Arc::clone(&doc.text))
+    }
+
+    /// The live buffer for `uri`, but only when the document is a manifest. The
+    /// third and last door into the read pool, and the narrowest: document
+    /// links are all a manifest answers, since a `path` entry is the only thing
+    /// in one that anchors anywhere — see
+    /// [`project_navigation`](super::project_navigation).
+    fn manifest_text(&self, uri: &Uri) -> Option<Arc<TextBuffer>> {
+        self.documents
+            .get(uri)
+            .filter(|doc| doc.kind == DocumentKind::Manifest)
             .map(|doc| Arc::clone(&doc.text))
     }
 
@@ -2488,9 +2512,10 @@ mod tests {
         }
     }
 
-    /// A manifest still answers nothing, for the same features a project file
-    /// now serves: its text never reaches the database, and its entries carry
-    /// no spans to anchor on.
+    /// A manifest still answers nothing for the features that resolve a name
+    /// through the environment: its text never reaches the database, and a
+    /// manifest names no package the way a `[deps]` key does. Document links
+    /// are the one exception — see the test below.
     #[test]
     fn a_manifest_answers_nothing_for_navigation() {
         let (mut state, channels) = test_state_with_channels();
@@ -2506,6 +2531,36 @@ mod tests {
             other => panic!("expected a response, got {other:?}"),
         }
         assert!(channels.read.try_recv().is_err(), "and no read job");
+    }
+
+    /// The exception: a manifest's `path` entries *are* document links, so its
+    /// buffer reaches the read pool for that one request — carrying the path it
+    /// resolves those entries against, which no other project-file job needs.
+    #[test]
+    fn a_manifest_buffer_reaches_the_read_pool_for_document_links() {
+        let (mut state, channels) = test_state_with_channels();
+        let manifest = uri("file:///work/Manifest.toml");
+        did_open(&mut state, &manifest, "[[deps.A]]\npath = \"../A\"\n");
+
+        state.on_request(Request::new(
+            RequestId::from(1),
+            DocumentLinkRequest::METHOD.to_string(),
+            DocumentLinkParams {
+                text_document: lsp_types::TextDocumentIdentifier {
+                    uri: manifest.clone(),
+                },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            },
+        ));
+
+        match channels.read.try_recv().expect("a read job") {
+            ReadJob::ManifestDocumentLinks { id, path, .. } => {
+                assert_eq!(id, RequestId::from(1));
+                assert_eq!(path, path_for(&manifest));
+            }
+            _ => panic!("expected a ManifestDocumentLinks read job"),
+        }
     }
 
     /// Inlay hints are a project file's alone, but unlike the other three a

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -39,7 +39,7 @@ use lsp_types::{
 };
 
 use crate::config::CONFIG_FILE_NAME;
-use crate::environment::{is_environment_file, is_project_file};
+use crate::environment::{is_environment_file, is_manifest_file, is_project_file};
 use crate::parser::Edit;
 use crate::text::{PositionEncoding, TextBuffer, apply_content_changes};
 
@@ -49,11 +49,44 @@ use super::read_jobs::{ReadJob, ReadReply};
 use super::server::HarvestSignal;
 use super::uri;
 
-/// An open document's live buffer and client-reported version.
+/// An open document's live buffer, client-reported version, and kind.
 #[derive(Debug, Clone)]
 struct Document {
     text: Arc<TextBuffer>,
     version: i32,
+    kind: DocumentKind,
+}
+
+/// What an open document *is*, decided once at `didOpen` from its path and
+/// carried on the buffer thereafter. Every fork that used to re-derive "is this
+/// an environment file?" from the URI now reads this instead: the two TOML
+/// kinds are not Julia, they never reach the parser, and each has a route of
+/// its own ([`GlobalState::route_document`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DocumentKind {
+    /// Julia source: the analysis pipeline's business, and the only kind any
+    /// language feature answers for.
+    Julia,
+    /// A `Project.toml` flavor. Its text reaches the database, because the
+    /// linter derives the package's declared dependencies from it; its buffer
+    /// also carries the file's own TOML diagnostics.
+    Project,
+    /// A `Manifest.toml` flavor. Diagnostics only: nothing reads a manifest
+    /// without an environment resolve, which is the harvester's job.
+    Manifest,
+}
+
+impl DocumentKind {
+    /// A document's kind, from the file its URI names. A URI with no path
+    /// behind it — an editor's untitled buffer — is Julia: it is what the
+    /// editor opened the server for, and it has no file name to say otherwise.
+    fn of(uri: &Uri) -> Self {
+        match uri::to_path(uri) {
+            Some(path) if is_project_file(&path) => Self::Project,
+            Some(path) if is_manifest_file(&path) => Self::Manifest,
+            _ => Self::Julia,
+        }
+    }
 }
 
 /// Messages from the analysis thread back to the main loop.
@@ -82,6 +115,11 @@ pub(crate) enum Outbound {
     /// report is served only for an open document, and an open environment
     /// file has no Julia analysis to carry them. So they always push, and a
     /// pull client neither suppresses nor re-supplies them.
+    ///
+    /// The harvester is not the only producer for these URIs: an *open*
+    /// environment file also carries the text-only findings of its own buffer
+    /// (`buffer_diags`), which arrive on the main loop rather than through this
+    /// channel. [`GlobalState::publish_merged`] is where the two cadences meet.
     EnvironmentDiagnostics { uri: Uri, diags: Vec<Diagnostic> },
     /// A re-harvest changed the include graph: a pull-model client should
     /// re-pull its open documents (`workspace/diagnostic/refresh`). Sent once
@@ -167,6 +205,13 @@ pub(crate) struct GlobalState {
     /// file on disk, open or not) nor cleared for a pull client on `didOpen`,
     /// as `graph_diags` is: there is no pull report that would re-supply them.
     env_diags: HashMap<Uri, Vec<Diagnostic>>,
+    /// The latest diagnostics an *open* environment file's own buffer produced
+    /// (see [`buffer_diagnostics`](super::environment_diagnostics::buffer_diagnostics)),
+    /// the second producer for the same URIs as `env_diags` — this one at edit
+    /// cadence rather than the harvester's resolve cadence. Non-empty entries
+    /// only, and dropped when the buffer closes: it describes a text only the
+    /// editor has.
+    buffer_diags: HashMap<Uri, Vec<Diagnostic>>,
     /// Per-document configuration: discovered `fatou.toml` shadowing
     /// editor-pushed settings (see [`ConfigStore`]). Owned by the main loop
     /// alone; resolved config travels with each dispatched request.
@@ -193,6 +238,7 @@ impl GlobalState {
             parse_diags: HashMap::new(),
             graph_diags: HashMap::new(),
             env_diags: HashMap::new(),
+            buffer_diags: HashMap::new(),
             sender,
             out_tx,
             inflight_reads: HashMap::new(),
@@ -260,17 +306,12 @@ impl GlobalState {
         };
         let uri = params.text_document.uri;
         // An environment file is TOML: there is nothing here to lint, and a
-        // Julia parse of it would report nonsense. Its own diagnostics reach
-        // the client by push (see `Outbound::EnvironmentDiagnostics`), which
-        // is the only route open to them — a pull report is served only for an
-        // open document, and these attach to files that need not be open.
-        let is_env = uri::to_path(&uri).is_some_and(|path| is_environment_file(&path));
-        let Some(text) = self
-            .documents
-            .get(&uri)
-            .filter(|_| !is_env)
-            .map(|d| Arc::clone(&d.text))
-        else {
+        // Julia parse of it would report nonsense (`julia_text` is what returns
+        // nothing for one). Its own diagnostics reach the client by push (see
+        // `Outbound::EnvironmentDiagnostics`), which stays the single route for
+        // them whether or not the client pulls — its two producers both push,
+        // so answering the pull with them as well would double them up.
+        let Some(text) = self.julia_text(&uri) else {
             // The spec wants a report, not null; an unknown document has none.
             let empty = serde_json::to_value(super::read_jobs::full_report(Vec::new()))
                 .expect("empty diagnostic report serializes");
@@ -296,7 +337,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -320,7 +361,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -343,7 +384,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -367,7 +408,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -405,7 +446,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -425,7 +466,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -446,7 +487,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -469,7 +510,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -491,7 +532,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -512,7 +553,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -533,7 +574,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -555,7 +596,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -576,7 +617,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -598,7 +639,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -623,7 +664,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -646,7 +687,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -667,7 +708,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -695,8 +736,9 @@ impl GlobalState {
         };
         let open_docs = self
             .documents
-            .keys()
-            .filter_map(uri::to_path)
+            .iter()
+            .filter(|(_, doc)| doc.kind == DocumentKind::Julia)
+            .filter_map(|(uri, _)| uri::to_path(uri))
             .collect::<Vec<_>>();
         let reply = self.read_reply(id.clone(), None);
         self.dispatch_read(ReadJob::WillRenameFiles {
@@ -716,7 +758,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -776,7 +818,7 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
-        let Some(text) = self.documents.get(&uri).map(|d| Arc::clone(&d.text)) else {
+        let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
         };
@@ -841,6 +883,20 @@ impl GlobalState {
         });
     }
 
+    /// The live buffer for `uri`, but only when the document is Julia. Every
+    /// language feature goes through this rather than `documents` directly:
+    /// with the environment files in the client's document selector, any
+    /// request can arrive for a `Project.toml`, and answering a hover or a
+    /// format for one would parse TOML as Julia and hand back nonsense. Such a
+    /// request answers `null`, exactly as it does for a document the server
+    /// never saw.
+    fn julia_text(&self, uri: &Uri) -> Option<Arc<TextBuffer>> {
+        self.documents
+            .get(uri)
+            .filter(|doc| doc.kind == DocumentKind::Julia)
+            .map(|doc| Arc::clone(&doc.text))
+    }
+
     /// Register an in-flight read against the buffer it was dispatched on and
     /// hand back its [`ReadReply`] channel. The recorded `(uri, version)` lets
     /// the reply be version-gated ([`Self::on_read_reply`]) and lets a
@@ -888,6 +944,9 @@ impl GlobalState {
                         Document {
                             text: Arc::new(TextBuffer::new(params.text_document.text)),
                             version: params.text_document.version,
+                            // The one place a document's kind is decided; every
+                            // later fork reads the tag rather than the path.
+                            kind: DocumentKind::of(&uri),
                         },
                     );
                     // A pull client takes over an opened document's
@@ -897,7 +956,7 @@ impl GlobalState {
                     if self.pull_diagnostics && self.graph_diags.contains_key(&uri) {
                         self.publish(uri.clone(), Vec::new(), None);
                     }
-                    self.send_analysis(uri, None);
+                    self.route_document(uri, None);
                 }
             }
             DidChangeTextDocument::METHOD => {
@@ -916,7 +975,7 @@ impl GlobalState {
                         self.encoding,
                     );
                     doc.version = params.text_document.version;
-                    self.send_analysis(uri, edits);
+                    self.route_document(uri, edits);
                 }
             }
             DidSaveTextDocument::METHOD => {
@@ -970,10 +1029,12 @@ impl GlobalState {
                     if let Some(path) = uri::to_path(&uri) {
                         let _ = self.sync_tx.send(SyncMessage::Revert(path));
                     }
-                    // Drop the buffer's parse diagnostics, but keep any project-
-                    // level include-graph diagnostics (they attach to the file on
-                    // disk, open or not): republish just those.
+                    // Drop what the buffer produced — its parse diagnostics, and
+                    // an environment file's live findings — but keep the
+                    // include-graph and harvester diagnostics (they attach to
+                    // the file on disk, open or not): republish just those.
                     self.parse_diags.remove(&uri);
+                    self.buffer_diags.remove(&uri);
                     self.publish_merged(uri, None);
                 }
             }
@@ -1245,15 +1306,101 @@ impl GlobalState {
     /// diagnostics — a single `publishDiagnostics` replaces *all* diagnostics
     /// for a URI, so every source must be sent together or each would clobber
     /// the others.
+    ///
+    /// The environment-file slot has two producers and takes only one of them:
+    /// an open buffer's live findings **supersede** the harvester's set rather
+    /// than joining it. The two are computed from different texts — the buffer
+    /// and the file on disk — so their union is a report of neither, and a
+    /// buffer that does not parse means the harvester's set (its own syntax
+    /// verdict, or semantic findings whose ranges index the disk text)
+    /// describes a file the user has already moved past. A buffer that parses
+    /// contributes nothing and leaves the harvester's set standing, which is
+    /// what keeps the semantic checks visible in an open file. The one seam:
+    /// fixing a syntax error without saving lets the disk verdict reappear
+    /// until the save — truthfully, since that is still the file Julia loads.
     fn publish_merged(&self, uri: Uri, version: Option<i32>) {
         let mut diagnostics = self.parse_diags.get(&uri).cloned().unwrap_or_default();
-        for source in [self.graph_diags.get(&uri), self.env_diags.get(&uri)]
+        let environment = self
+            .buffer_diags
+            .get(&uri)
+            .or_else(|| self.env_diags.get(&uri));
+        for source in [self.graph_diags.get(&uri), environment]
             .into_iter()
             .flatten()
         {
             diagnostics.extend(source.iter().cloned());
         }
         self.publish(uri, diagnostics, version);
+    }
+
+    /// Route a document's new text to whatever owns it, by
+    /// [kind](DocumentKind) — the one fork every `didOpen`/`didChange` takes.
+    ///
+    /// Julia goes to the analysis pipeline. An environment file (`Project.toml`
+    /// and friends) is TOML, and parsing it as Julia would publish nonsense
+    /// parse errors that [`publish_merged`](Self::publish_merged) would union
+    /// with the file's real diagnostics; it takes the TOML route instead, which
+    /// re-derives the file's own findings from the buffer. A *project* file
+    /// additionally writes its text to the database, because the linter derives
+    /// the package's declared dependencies from it — that is what lets an
+    /// unsaved `[deps]` edit reach `unresolved-import` across the package. A
+    /// manifest sends no text: nothing reads one without an environment
+    /// resolve, which is the harvester's job.
+    ///
+    /// `edits` belong to the Julia route alone (see
+    /// [`send_analysis`](Self::send_analysis)).
+    fn route_document(&mut self, uri: Uri, edits: Option<Vec<Edit>>) {
+        match self.documents.get(&uri).map(|doc| doc.kind) {
+            None => {}
+            Some(DocumentKind::Julia) => self.send_analysis(uri, edits),
+            Some(kind) => {
+                if kind == DocumentKind::Project {
+                    self.send_project_text(&uri);
+                }
+                self.refresh_buffer_diagnostics(uri);
+            }
+        }
+    }
+
+    /// Write an open project file's buffer to the database as text, so the
+    /// linter's declared dependencies follow the editor rather than the disk.
+    fn send_project_text(&self, uri: &Uri) {
+        let (Some(path), Some(doc)) = (uri::to_path(uri), self.documents.get(uri)) else {
+            return;
+        };
+        let _ = self.sync_tx.send(SyncMessage::SetText {
+            path,
+            text: doc.text.text().to_string(),
+        });
+    }
+
+    /// Re-derive an open environment file's own diagnostics from its buffer and
+    /// republish — the live half of the split stage 2 drew, and the second
+    /// producer for these URIs.
+    ///
+    /// Only the buffer's own set is bookkept here; the merge with the
+    /// harvester's is [`publish_merged`](Self::publish_merged)'s. A publish is
+    /// sent only when there is something to say or something to take back, so a
+    /// keystroke in a file that parses puts nothing on the wire.
+    fn refresh_buffer_diagnostics(&mut self, uri: Uri) {
+        let (Some(path), Some(doc)) = (uri::to_path(&uri), self.documents.get(&uri)) else {
+            return;
+        };
+        let version = doc.version;
+        let diags = super::environment_diagnostics::buffer_diagnostics(
+            &path,
+            doc.text.text(),
+            self.encoding,
+        );
+        let had = self.buffer_diags.remove(&uri).is_some();
+        if diags.is_empty() {
+            if !had {
+                return;
+            }
+        } else {
+            self.buffer_diags.insert(uri.clone(), diags);
+        }
+        self.publish_merged(uri, Some(version));
     }
 
     /// Send an analysis request for `uri`'s current buffer to the analysis
@@ -1264,33 +1411,7 @@ impl GlobalState {
     /// means the transform is unknown — a fresh `didOpen`, a whole-buffer
     /// replacement, or a re-analysis of unchanged text under new rules — and
     /// the reparse falls back to diffing the two texts.
-    ///
-    /// An environment file (`Project.toml` and friends) is TOML, not Julia:
-    /// parsing it here would publish nonsense parse errors that
-    /// [`publish_merged`](Self::publish_merged) would union with the real
-    /// environment diagnostics on the same URI. The buffer stays tracked, so
-    /// `didChange` and `didClose` behave as they do for any document; it is
-    /// only never analyzed. Guarded here rather than at the `didOpen` call
-    /// site so `didChange` and [`on_config_changed`](Self::on_config_changed)
-    /// are covered by the same return.
-    ///
-    /// A *project* file takes the other fork instead: its text goes to the db
-    /// as text, because the linter derives the package's declared dependencies
-    /// from it. That is what lets an unsaved `[deps]` edit reach
-    /// `unresolved-import` across the package. A manifest takes neither fork —
-    /// nothing reads it without a resolve, which is the harvester's job.
     fn send_analysis(&mut self, uri: Uri, edits: Option<Vec<Edit>>) {
-        if let Some(path) = uri::to_path(&uri).filter(|path| is_environment_file(path)) {
-            if is_project_file(&path)
-                && let Some(doc) = self.documents.get(&uri)
-            {
-                let _ = self.sync_tx.send(SyncMessage::SetText {
-                    path,
-                    text: doc.text.text().to_string(),
-                });
-            }
-            return;
-        }
         let rules = Arc::clone(&self.config_for(&uri).rules);
         let Some(doc) = self.documents.get(&uri) else {
             return;
@@ -1334,14 +1455,15 @@ impl GlobalState {
         if self.pull_diagnostics {
             self.send_diagnostic_refresh();
         } else {
-            // Environment files are skipped: they publish no analysis, and
-            // re-sending an unchanged project buffer through `send_analysis`
-            // would only write it back to the db it just came from.
+            // Environment files are skipped: they publish no analysis, their
+            // own findings answer to the buffer rather than to the premises
+            // that moved, and re-routing an unchanged project buffer would only
+            // write it back to the db it just came from.
             let uris: Vec<Uri> = self
                 .documents
-                .keys()
-                .filter(|uri| uri::to_path(uri).is_none_or(|path| !is_environment_file(&path)))
-                .cloned()
+                .iter()
+                .filter(|(_, doc)| doc.kind == DocumentKind::Julia)
+                .map(|(uri, _)| uri.clone())
                 .collect();
             for uri in uris {
                 self.send_analysis(uri, None);
@@ -1502,6 +1624,7 @@ mod tests {
             Document {
                 text: Arc::default(),
                 version,
+                kind: DocumentKind::of(uri),
             },
         );
     }
@@ -1536,6 +1659,7 @@ mod tests {
             Document {
                 text: Arc::new(TextBuffer::from("x = 1\n")),
                 version: 1,
+                kind: DocumentKind::Julia,
             },
         );
         // What the analysis thread and any read job hold onto.
@@ -1827,6 +1951,36 @@ mod tests {
         state.on_notification(note);
     }
 
+    /// Drive a whole-buffer `didChange`, as a client would.
+    fn did_change(state: &mut GlobalState, uri: &Uri, version: i32, text: &str) {
+        let note = Notification::new(
+            DidChangeTextDocument::METHOD.to_string(),
+            DidChangeTextDocumentParams {
+                text_document: lsp_types::VersionedTextDocumentIdentifier {
+                    uri: uri.clone(),
+                    version,
+                },
+                content_changes: vec![lsp_types::TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: text.to_string(),
+                }],
+            },
+        );
+        state.on_notification(note);
+    }
+
+    /// The check IDs a published set carries, in order.
+    fn codes(diags: &[Diagnostic]) -> Vec<&str> {
+        diags
+            .iter()
+            .filter_map(|diag| match &diag.code {
+                Some(NumberOrString::String(code)) => Some(code.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// An environment file is TOML, so it must never reach the Julia analysis.
     /// The document is still tracked — `didChange`/`didClose` stay consistent —
     /// but no `AnalysisRequest` is dispatched for it.
@@ -2068,6 +2222,189 @@ mod tests {
         assert!(
             channels.read.try_recv().is_err(),
             "no read job is dispatched for a TOML buffer"
+        );
+    }
+
+    /// An open environment file's *own* diagnostics come from its buffer, at
+    /// edit cadence: a `Project.toml` that does not parse reports on itself
+    /// with no save and no harvest.
+    #[test]
+    fn a_broken_project_buffer_publishes_its_syntax_error() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+
+        did_open(&mut state, &project, "name = \"Demo\"\nuuid = \n");
+
+        let (diags, version) = next_publish(&channels.client);
+        let [diag] = &diags[..] else {
+            panic!("expected one diagnostic, got {diags:?}");
+        };
+        assert_eq!(codes(&diags), vec!["toml-syntax"]);
+        assert_eq!(diag.range.start.line, 1, "the `uuid = ` line");
+        assert_eq!(version, Some(1), "tagged with the buffer it describes");
+    }
+
+    /// A manifest buffer takes the same route: nothing reads it without a
+    /// resolve, but its syntax is text-only and so is the buffer's to answer.
+    #[test]
+    fn a_broken_manifest_buffer_publishes_its_syntax_error() {
+        let (mut state, channels) = test_state_with_channels();
+        let manifest = uri("file:///work/Manifest.toml");
+
+        did_open(&mut state, &manifest, "[[deps\n");
+
+        assert_eq!(
+            codes(&next_publish(&channels.client).0),
+            vec!["toml-syntax"]
+        );
+        assert!(
+            channels.sync.try_recv().is_err(),
+            "and still never reaches the database"
+        );
+    }
+
+    /// Two producers write one environment file's diagnostics: the harvester,
+    /// off disk at resolve cadence, and the open buffer, at edit cadence. They
+    /// are never unioned — computed from different texts, their union is a
+    /// report of neither. A live syntax error supersedes the harvester's set
+    /// (whose ranges index a text the user has moved past), and a buffer that
+    /// parses hands the file back.
+    #[test]
+    fn a_live_syntax_error_supersedes_the_harvesters_findings() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+        state.on_outbound(Outbound::EnvironmentDiagnostics {
+            uri: project.clone(),
+            diags: vec![diag("no [compat] bound on julia")],
+        });
+        let _ = next_publish(&channels.client);
+
+        // Opened, and it parses: the buffer has nothing to say, so the
+        // harvester's finding stands and nothing is republished.
+        did_open(&mut state, &project, "name = \"Demo\"\n");
+        assert!(
+            channels.client.try_recv().is_err(),
+            "a clean buffer publishes nothing of its own"
+        );
+
+        // Edited into a syntax error: the buffer's verdict is the fresher one.
+        did_change(&mut state, &project, 2, "name = \"Demo\"\nuuid = \n");
+        let (diags, version) = next_publish(&channels.client);
+        assert_eq!(codes(&diags), vec!["toml-syntax"]);
+        assert_eq!(version, Some(2));
+
+        // Fixed, still unsaved: the harvester's set takes the file back.
+        did_change(&mut state, &project, 3, "name = \"Demo\"\n");
+        let (diags, _) = next_publish(&channels.client);
+        assert_eq!(
+            diags.iter().map(|d| d.message.as_str()).collect::<Vec<_>>(),
+            vec!["no [compat] bound on julia"],
+        );
+    }
+
+    /// The live findings go with the buffer: closing hands the file back to the
+    /// harvester's set, which describes it on disk, open or not.
+    #[test]
+    fn closing_an_environment_buffer_drops_its_live_findings() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+        state.on_outbound(Outbound::EnvironmentDiagnostics {
+            uri: project.clone(),
+            diags: vec![diag("no [compat] bound on julia")],
+        });
+        let _ = next_publish(&channels.client);
+        did_open(&mut state, &project, "uuid = \n");
+        assert_eq!(
+            codes(&next_publish(&channels.client).0),
+            vec!["toml-syntax"]
+        );
+
+        state.on_notification(Notification::new(
+            DidCloseTextDocument::METHOD.to_string(),
+            DidCloseTextDocumentParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: project },
+            },
+        ));
+
+        let (diags, _) = next_publish(&channels.client);
+        assert_eq!(
+            diags.iter().map(|d| d.message.as_str()).collect::<Vec<_>>(),
+            vec!["no [compat] bound on julia"],
+        );
+    }
+
+    /// With the environment files in the client's document selector, every
+    /// request can now arrive for one. Nothing Julia-backed may answer: a
+    /// format or a hover would parse TOML as Julia and hand back nonsense, so
+    /// they answer `null`, as they do for a document the server never saw.
+    #[test]
+    fn language_features_answer_nothing_for_an_environment_document() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+        did_open(&mut state, &project, "[deps]\n");
+
+        let document = lsp_types::TextDocumentIdentifier { uri: project };
+        let requests = [
+            Request::new(
+                RequestId::from(1),
+                Formatting::METHOD.to_string(),
+                DocumentFormattingParams {
+                    text_document: document.clone(),
+                    options: Default::default(),
+                    work_done_progress_params: Default::default(),
+                },
+            ),
+            Request::new(
+                RequestId::from(2),
+                DocumentSymbolRequest::METHOD.to_string(),
+                DocumentSymbolParams {
+                    text_document: document.clone(),
+                    work_done_progress_params: Default::default(),
+                    partial_result_params: Default::default(),
+                },
+            ),
+        ];
+        for request in requests {
+            let id = request.id.clone();
+            state.on_request(request);
+            match channels.client.try_recv().expect("a response") {
+                Message::Response(resp) => {
+                    assert_eq!(resp.id, id);
+                    assert_eq!(
+                        resp.response_result.ok(),
+                        Some(serde_json::Value::Null),
+                        "for {id}"
+                    );
+                }
+                other => panic!("expected a response, got {other:?}"),
+            }
+        }
+        assert!(
+            channels.read.try_recv().is_err(),
+            "and no TOML buffer reaches the read pool"
+        );
+    }
+
+    /// A buffer with no file name behind it — an editor's untitled document —
+    /// is Julia: it is what the editor opened the server for, and there is no
+    /// file name to say otherwise.
+    #[test]
+    fn an_untitled_buffer_is_julia() {
+        assert_eq!(
+            DocumentKind::of(&uri("untitled:Untitled-1")),
+            DocumentKind::Julia
+        );
+        assert_eq!(
+            DocumentKind::of(&uri("file:///work/Project.toml")),
+            DocumentKind::Project
+        );
+        assert_eq!(
+            DocumentKind::of(&uri("file:///work/Manifest-v1.11.toml")),
+            DocumentKind::Manifest
+        );
+        assert_eq!(
+            DocumentKind::of(&uri("file:///work/src/a.jl")),
+            DocumentKind::Julia
         );
     }
 }

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -1150,12 +1150,21 @@ impl GlobalState {
     /// event escalates to one environment re-resolve for the whole batch (which
     /// subsumes any per-package re-harvest); otherwise each `.jl` event
     /// re-harvests the workspace package owning the file, so created and
-    /// deleted members refresh the membership. A `.jl` file with no open buffer
-    /// is first synced to disk — the seeded text must not go stale when the
-    /// file changes outside the editor — while an open buffer stays
-    /// authoritative until it closes (a create not yet tracked and a delete no
-    /// longer readable both sync as no-ops; the re-harvest itself adds or drops
-    /// the member).
+    /// deleted members refresh the membership. A file with no open buffer is
+    /// first synced to disk — the seeded text must not go stale when the file
+    /// changes outside the editor — while an open buffer stays authoritative
+    /// until it closes (a create not yet tracked and a delete no longer
+    /// readable both sync as no-ops; the re-harvest itself adds or drops the
+    /// member).
+    ///
+    /// The sync covers the **project files too**, not just `.jl` sources: their
+    /// `[deps]` is read off the tracked input now
+    /// ([`project_declared_deps`](crate::incremental::project_declared_deps)),
+    /// and the re-resolve an environment event triggers cannot refresh it —
+    /// `set_project_files` is create-or-return, so as not to clobber an open
+    /// buffer with the disk copy. Without the sync, a `pkg> add` in a terminal
+    /// would leave `unresolved-import` answering to the text the file had when
+    /// the server first harvested it.
     fn on_watched_files(&mut self, params: DidChangeWatchedFilesParams) {
         // A created, changed, or deleted `fatou.toml` reshapes discovery for
         // every cached directory; drop the cache wholesale and re-derive the
@@ -1180,12 +1189,16 @@ impl GlobalState {
             let Some(path) = uri::to_path(&event.uri) else {
                 continue;
             };
-            if is_environment_file(&path) || path.extension().is_none_or(|ext| ext != "jl") {
+            let is_env = is_environment_file(&path);
+            if !is_env && path.extension().is_none_or(|ext| ext != "jl") {
                 continue;
             }
             if !self.documents.contains_key(&event.uri) {
                 let _ = self.sync_tx.send(SyncMessage::Revert(path.clone()));
             }
+            // An environment event sets `environment_changed`, so this arm is
+            // the `.jl` one: a project file re-resolves as a batch below rather
+            // than naming a package to re-harvest on its own.
             if !environment_changed {
                 let _ = self.harvest_tx.send(HarvestSignal::Source(path));
             }
@@ -1978,6 +1991,50 @@ mod tests {
             ],
             "the vacated and the occupied path each re-harvest their package"
         );
+    }
+
+    /// A `Project.toml` changed outside the editor — `pkg> add`, a branch
+    /// switch — must reach the tracked input, exactly as a `.jl` file does. The
+    /// declared dependencies are read off that input now, so without the sync
+    /// the re-resolve this also triggers would leave `unresolved-import`
+    /// answering to the text the file had when the server started.
+    #[test]
+    fn a_watched_project_file_with_no_buffer_syncs_to_disk() {
+        let (mut state, channels) = test_state_with_channels();
+        let (path, _) = native("Project.toml");
+
+        state.on_watched_files(DidChangeWatchedFilesParams {
+            changes: vec![lsp_types::FileEvent {
+                uri: uri::from_path(&path).expect("a file URI"),
+                typ: lsp_types::FileChangeType::CHANGED,
+            }],
+        });
+
+        assert_eq!(reverted(&channels.sync), vec![path]);
+        assert_eq!(
+            channels.harvest.try_iter().collect::<Vec<_>>(),
+            vec![HarvestSignal::Environment],
+            "and it still escalates to a full re-resolve"
+        );
+    }
+
+    /// An open buffer stays authoritative: the editor owns the text until it
+    /// closes, and reverting under it would drop the user's unsaved `[deps]`.
+    #[test]
+    fn a_watched_project_file_with_an_open_buffer_does_not_sync() {
+        let (mut state, channels) = test_state_with_channels();
+        let (path, _) = native("Project.toml");
+        let uri = uri::from_path(&path).expect("a file URI");
+        open(&mut state, &uri, 1);
+
+        state.on_watched_files(DidChangeWatchedFilesParams {
+            changes: vec![lsp_types::FileEvent {
+                uri: uri.clone(),
+                typ: lsp_types::FileChangeType::CHANGED,
+            }],
+        });
+
+        assert!(channels.sync.try_recv().is_err());
     }
 
     #[test]

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -617,6 +617,19 @@ impl GlobalState {
             return;
         };
         let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        // A project file resolves a dependency name to its package's source; a
+        // Julia document resolves a symbol. Anything else answers `null`.
+        if let Some(text) = self.project_text(&uri) {
+            let reply = self.read_reply(id.clone(), Some(&uri));
+            self.dispatch_read(ReadJob::ProjectDefinition {
+                id,
+                text,
+                position,
+                sender: reply,
+            });
+            return;
+        }
         let Some(text) = self.julia_text(&uri) else {
             self.respond_ok(id, serde_json::Value::Null);
             return;
@@ -625,7 +638,7 @@ impl GlobalState {
         self.dispatch_read(ReadJob::Definition {
             id,
             path: path_for(&uri),
-            position: params.text_document_position_params.position,
+            position,
             uri,
             text,
             sender: reply,
@@ -894,6 +907,23 @@ impl GlobalState {
         self.documents
             .get(uri)
             .filter(|doc| doc.kind == DocumentKind::Julia)
+            .map(|doc| Arc::clone(&doc.text))
+    }
+
+    /// The live buffer for `uri`, but only when the document is a project file.
+    /// The sibling of [`julia_text`](Self::julia_text), and the *only* other
+    /// door into the read pool: a feature that understands TOML asks here,
+    /// everything Julia-backed keeps asking there, and a handler that calls
+    /// neither still answers `null` as before.
+    ///
+    /// A `Manifest.toml` deliberately answers nothing. Its text never reaches
+    /// the database (nothing reads a manifest without an environment resolve),
+    /// and its entries carry no spans to anchor on — see
+    /// [`project_navigation`](super::project_navigation).
+    fn project_text(&self, uri: &Uri) -> Option<Arc<TextBuffer>> {
+        self.documents
+            .get(uri)
+            .filter(|doc| doc.kind == DocumentKind::Project)
             .map(|doc| Arc::clone(&doc.text))
     }
 
@@ -1544,6 +1574,7 @@ fn harvest_signal(path: PathBuf) -> HarvestSignal {
 mod tests {
     use super::*;
     use crossbeam_channel::{Receiver, unbounded};
+    use lsp_types::Position;
     use std::str::FromStr;
 
     /// A `GlobalState` wired to in-memory channels, returned with the client's
@@ -2334,9 +2365,11 @@ mod tests {
     }
 
     /// With the environment files in the client's document selector, every
-    /// request can now arrive for one. Nothing Julia-backed may answer: a
-    /// format or a hover would parse TOML as Julia and hand back nonsense, so
-    /// they answer `null`, as they do for a document the server never saw.
+    /// request can now arrive for one. Nothing **Julia-backed** may answer: a
+    /// format or a document symbol would parse TOML as Julia and hand back
+    /// nonsense, so they answer `null`, as they do for a document the server
+    /// never saw. The TOML-aware features are the exception, and go through
+    /// `project_text` instead — see the two tests below.
     #[test]
     fn language_features_answer_nothing_for_an_environment_document() {
         let (mut state, channels) = test_state_with_channels();
@@ -2381,8 +2414,64 @@ mod tests {
         }
         assert!(
             channels.read.try_recv().is_err(),
-            "and no TOML buffer reaches the read pool"
+            "and no TOML buffer reaches the read pool for a Julia-backed feature"
         );
+    }
+
+    /// The other side of the fork: a project file *does* reach the read pool
+    /// for a feature that understands TOML, so a `[deps]` name can resolve to
+    /// its package.
+    #[test]
+    fn a_project_buffer_reaches_the_read_pool_for_navigation() {
+        let (mut state, channels) = test_state_with_channels();
+        let project = uri("file:///work/Project.toml");
+        did_open(&mut state, &project, "[deps]\nA = \"x\"\n");
+
+        state.on_request(definition_request(1, &project));
+
+        match channels.read.try_recv().expect("a read job") {
+            ReadJob::ProjectDefinition { id, position, .. } => {
+                assert_eq!(id, RequestId::from(1));
+                assert_eq!(position, Position::new(1, 0));
+            }
+            _ => panic!("expected a ProjectDefinition read job"),
+        }
+    }
+
+    /// A manifest still answers nothing, for the same features a project file
+    /// now serves: its text never reaches the database, and its entries carry
+    /// no spans to anchor on.
+    #[test]
+    fn a_manifest_answers_nothing_for_navigation() {
+        let (mut state, channels) = test_state_with_channels();
+        let manifest = uri("file:///work/Manifest.toml");
+        did_open(&mut state, &manifest, "manifest_format = \"2.0\"\n");
+
+        state.on_request(definition_request(1, &manifest));
+
+        match channels.client.try_recv().expect("a response") {
+            Message::Response(resp) => {
+                assert_eq!(resp.response_result.ok(), Some(serde_json::Value::Null));
+            }
+            other => panic!("expected a response, got {other:?}"),
+        }
+        assert!(channels.read.try_recv().is_err(), "and no read job");
+    }
+
+    /// A `textDocument/definition` at line 1, column 0 of `uri`.
+    fn definition_request(id: i32, uri: &Uri) -> Request {
+        Request::new(
+            RequestId::from(id),
+            GotoDefinition::METHOD.to_string(),
+            GotoDefinitionParams {
+                text_document_position_params: lsp_types::TextDocumentPositionParams {
+                    text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                    position: Position::new(1, 0),
+                },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            },
+        )
     }
 
     /// A buffer with no file name behind it — an editor's untitled document —

--- a/src/lsp/uri.rs
+++ b/src/lsp/uri.rs
@@ -90,6 +90,20 @@ pub(crate) fn is_synthetic(path: &Path) -> bool {
     path.parent() == Some(synthetic_dir().as_path())
 }
 
+/// The directory a relative path *inside* the document at `path` resolves
+/// against: its parent. `None` when there is no such directory — a
+/// [synthetic](is_synthetic) stand-in for a non-`file` URI names no real one,
+/// and a parentless path names none either.
+///
+/// One definition, because two features ask it: a Julia document's `include`
+/// paths and a manifest's `path` entries.
+pub(crate) fn anchor_dir(path: &Path) -> Option<&Path> {
+    if is_synthetic(path) {
+        return None;
+    }
+    path.parent().filter(|dir| !dir.as_os_str().is_empty())
+}
+
 /// Build a `file:` URI for the absolute filesystem `path`, percent-encoding
 /// characters outside the unreserved set. The inverse of [`to_path`]; used to
 /// point a go-to-definition [`Location`](lsp_types::Location) at a depot source

--- a/src/project_files.rs
+++ b/src/project_files.rs
@@ -33,7 +33,7 @@ use toml::Spanned;
 
 use crate::environment::{
     Environment, EnvironmentError, PackageKind, ProjectFile, Uuid, is_project_file,
-    parse_project_str, parse_project_text,
+    manifest_path_entries, parse_project_str, parse_project_text,
 };
 use crate::linter::Severity;
 
@@ -372,6 +372,59 @@ pub fn dep_at(text: &str, offset: usize) -> Option<DepEntry> {
         .find(|entry| entry.name_range.contains_inclusive(offset))
 }
 
+// --- Manifest path entries -------------------------------------------------
+
+/// One `path = "..."` entry of a manifest: the package it pins, the path as
+/// written, and where that path's text sits.
+///
+/// The manifest's counterpart to [`DepEntry`], and the only thing inside a
+/// manifest that anchors anywhere — every other field either names the package
+/// (the key), or names nothing outside the file at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestPath {
+    pub name: String,
+    /// The path as written, decoded: relative to the manifest's directory
+    /// unless absolute, exactly as the environment resolves a `dev`'d root.
+    pub path: String,
+    /// The path text with its quotes trimmed, unlike [`DepEntry::uuid_range`]:
+    /// this range is what a client underlines as a link, and the quotes are not
+    /// part of the path.
+    pub range: TextRange,
+}
+
+/// Every `path = "..."` entry in a manifest's text, in source order. Empty when
+/// the text does not parse, on the same terms as [`dep_entries`].
+pub fn manifest_paths(text: &str) -> Vec<ManifestPath> {
+    let mut entries: Vec<ManifestPath> = manifest_path_entries(text)
+        .into_iter()
+        .map(|(name, path)| ManifestPath {
+            name,
+            range: unquoted(text, span(&path)),
+            path: path.into_inner(),
+        })
+        .collect();
+    // The schema's map is name-keyed; source order is what a caller enumerating
+    // a document wants, as in [`dep_entries`].
+    entries.sort_by_key(|entry| entry.range.start());
+    entries
+}
+
+/// A string value's span with its delimiters trimmed. A multi-line string
+/// (`"""..."""`) keeps its span whole rather than shedding two of six
+/// delimiters — no path is spelled that way, and a wrong range is worse than a
+/// wide one.
+fn unquoted(text: &str, range: TextRange) -> TextRange {
+    let mut chars = text[range].chars();
+    let (Some(open), Some(close)) = (chars.next(), chars.next_back()) else {
+        return range;
+    };
+    if open != close || !matches!(open, '"' | '\'') || chars.as_str().starts_with(open) {
+        return range;
+    }
+    let quote = TextSize::of(open);
+    TextRange::new(range.start() + quote, range.end() - quote)
+}
+
 /// A spanned value's byte range.
 fn span<T>(spanned: &Spanned<T>) -> TextRange {
     let span = spanned.span();
@@ -545,6 +598,91 @@ Test = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"
     #[test]
     fn a_project_file_with_no_dependencies_has_no_entries() {
         assert!(dep_entries("name = \"Demo\"\n\n[deps]\n").is_empty());
+    }
+
+    // --- Manifest path entries ----------------------------------------------
+
+    /// Format 2.0: every entry under a top-level `deps` table, beside the
+    /// scalar metadata keys that make the 1.0 schema reject the same text.
+    const MANIFEST_V2: &str = "\
+julia_version = \"1.11.7\"
+manifest_format = \"2.0\"
+
+[[deps.AbstractTrees]]
+uuid = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
+version = \"0.4.5\"
+
+[[deps.Greetings]]
+uuid = \"682c06a0-de6a-54ab-a142-c8b1cf79cde6\"
+path = \"../Greetings\"
+
+[[deps.Neighbor]]
+uuid = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"
+path = \"/abs/Neighbor\"
+";
+
+    /// Format 1.0: each package's array at the top level, no metadata at all.
+    const MANIFEST_V1: &str = "\
+[[Greetings]]
+uuid = \"682c06a0-de6a-54ab-a142-c8b1cf79cde6\"
+path = \"../Greetings\"
+
+[[AbstractTrees]]
+uuid = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
+version = \"0.4.5\"
+";
+
+    /// Both layouts answer, and only the `dev`'d entries do: a registered
+    /// package pins a `git-tree-sha1`, not a path, and names nothing to open.
+    #[test]
+    fn manifest_paths_read_both_layouts() {
+        let v2: Vec<(String, String)> = manifest_paths(MANIFEST_V2)
+            .into_iter()
+            .map(|entry| (entry.name, entry.path))
+            .collect();
+        assert_eq!(
+            v2,
+            vec![
+                ("Greetings".to_string(), "../Greetings".to_string()),
+                ("Neighbor".to_string(), "/abs/Neighbor".to_string()),
+            ],
+            "in source order, and no entry without a path"
+        );
+
+        let v1: Vec<(String, String)> = manifest_paths(MANIFEST_V1)
+            .into_iter()
+            .map(|entry| (entry.name, entry.path))
+            .collect();
+        assert_eq!(
+            v1,
+            vec![("Greetings".to_string(), "../Greetings".to_string())]
+        );
+    }
+
+    /// The range is what a client underlines, so it covers the path and not the
+    /// quotes around it — unlike [`DepEntry::uuid_range`], which is a
+    /// diagnostic's anchor.
+    #[test]
+    fn a_manifest_path_spans_the_path_text_without_its_quotes() {
+        let entries = manifest_paths(MANIFEST_V2);
+        let greetings = entries.first().expect("the first entry");
+        assert_eq!(&MANIFEST_V2[greetings.range], "../Greetings");
+
+        // A literal string is delimited too, and an empty one trims to nothing
+        // rather than underflowing.
+        let literal = "[[deps.Greetings]]\npath = '../Greetings'\n";
+        assert_eq!(&literal[manifest_paths(literal)[0].range], "../Greetings");
+        let empty = "[[deps.Greetings]]\npath = \"\"\n";
+        assert!(manifest_paths(empty)[0].range.is_empty());
+    }
+
+    /// Half-typed TOML anchors nothing, and neither does a project file: the
+    /// two schemas are disjoint, so a `Project.toml` read as a manifest must
+    /// not manufacture entries from `[deps]`.
+    #[test]
+    fn a_manifest_that_does_not_parse_has_no_paths() {
+        assert!(manifest_paths("[[deps.Greetings\npath = \"x\"\n").is_empty());
+        assert!(manifest_paths(TABLES).is_empty());
     }
 
     // --- The semantic checks ------------------------------------------------

--- a/src/project_files.rs
+++ b/src/project_files.rs
@@ -14,9 +14,16 @@
 //! against `lsp_types` in `crate::lsp::graph_diagnostics` and then had to be
 //! written a *second* time for the CLI in `crate::linter::include_graph`.
 //!
-//! Two entry points, because a syntax failure is precisely the case where there
-//! is no [`Environment`] to check: [`syntax_findings`] reports on one file's
-//! text, and [`semantic_findings`] reports on a resolved environment.
+//! Two entry points for the checks, because a syntax failure is precisely the
+//! case where there is no [`Environment`] to check: [`syntax_findings`] reports
+//! on one file's text, and [`semantic_findings`] reports on a resolved
+//! environment.
+//!
+//! [`dep_entries`] is the same knowledge read the other way: not "what is wrong
+//! with this file" but "what does it name, and where". It is what
+//! go-to-definition, hover, and document links over an open `Project.toml`
+//! resolve against, and it lives here for the same reason the checks do — one
+//! spanned schema, one place that turns a `Spanned` into a [`TextRange`].
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -26,7 +33,7 @@ use toml::Spanned;
 
 use crate::environment::{
     Environment, EnvironmentError, PackageKind, ProjectFile, Uuid, is_project_file,
-    parse_project_text,
+    parse_project_str, parse_project_text,
 };
 use crate::linter::Severity;
 
@@ -292,6 +299,79 @@ fn manifest_findings(env: &Environment, project: &ProjectFile) -> Vec<ProjectFin
     findings
 }
 
+// --- Dependency entries ----------------------------------------------------
+
+/// Which of a project file's dependency-naming tables an entry came from.
+///
+/// All three name a real package, which is why all three are here and
+/// `[compat]` is not: a compat key names a dependency *or* `julia`, and
+/// nothing that navigates by package name can resolve the latter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepTable {
+    Deps,
+    WeakDeps,
+    Extras,
+}
+
+/// One `Name = "uuid"` entry of a dependency-naming table, with the byte range
+/// of its key and of its value.
+///
+/// The navigation counterpart of a [`ProjectFinding`]: same schema, same
+/// spans, same deliberate independence from `lsp_types`. Go-to-definition,
+/// hover, and document links all anchor on
+/// [`name_range`](Self::name_range) — the name is what resolves to a package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DepEntry {
+    pub name: String,
+    pub table: DepTable,
+    pub name_range: TextRange,
+    /// The value's span, quotes included, exactly as `uuid-mismatch` reports it.
+    pub uuid_range: TextRange,
+}
+
+/// Every dependency entry in a project file's text, in source order.
+///
+/// Empty when the text does not parse: half-typed TOML must not produce a
+/// bogus jump, and the file's own `toml-syntax` finding already reports the
+/// state it is in.
+pub fn dep_entries(text: &str) -> Vec<DepEntry> {
+    let Some(project) = parse_project_str(text) else {
+        return Vec::new();
+    };
+    let tables = [
+        (DepTable::Deps, &project.deps),
+        (DepTable::WeakDeps, &project.weakdeps),
+        (DepTable::Extras, &project.extras),
+    ];
+    let mut entries: Vec<DepEntry> = tables
+        .into_iter()
+        .flat_map(|(table, map)| {
+            map.iter().map(move |(name, uuid)| DepEntry {
+                name: name.as_ref().clone(),
+                table,
+                name_range: span(name),
+                uuid_range: span(uuid),
+            })
+        })
+        .collect();
+    // The schema's maps are name-keyed, so their iteration order is alphabetical
+    // within a table; source order is what a caller enumerating a document wants.
+    entries.sort_by_key(|entry| entry.name_range.start());
+    entries
+}
+
+/// The dependency entry whose *name* covers `offset`, if any.
+///
+/// Both ends of the name are included: an LSP position sits between characters,
+/// so a cursor just past the last one is still on the name. Two entries can
+/// never share an offset — a `= "uuid"` always separates them.
+pub fn dep_at(text: &str, offset: usize) -> Option<DepEntry> {
+    let offset = TextSize::new(u32::try_from(offset).ok()?);
+    dep_entries(text)
+        .into_iter()
+        .find(|entry| entry.name_range.contains_inclusive(offset))
+}
+
 /// A spanned value's byte range.
 fn span<T>(spanned: &Spanned<T>) -> TextRange {
     let span = spanned.span();
@@ -365,6 +445,106 @@ mod tests {
         assert!(syntax_findings(manifest, "name = 42\n").is_empty());
 
         assert_eq!(syntax_findings(manifest, "[[deps\n").len(), 1);
+    }
+
+    // --- Dependency entries -------------------------------------------------
+
+    const TABLES: &str = "\
+name = \"Demo\"
+
+[deps]
+AbstractTrees = \"1520ce14-60c1-5f80-bbc7-55ef81b5835c\"
+JSON = \"682c06a0-de6a-54ab-a142-c8b1cf79cde6\"
+
+[compat]
+julia = \"1.10\"
+
+[weakdeps]
+Plots = \"91a5bcdd-55d7-5caf-9e0b-520d859cae80\"
+
+[extras]
+Test = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"
+";
+
+    /// The byte offset of `needle`'s first occurrence, so a test names a
+    /// position by what it points at rather than by a hand-counted number.
+    fn at(text: &str, needle: &str) -> usize {
+        text.find(needle).expect("needle in text")
+    }
+
+    /// All three tables name real packages, and all three answer. `[compat]`
+    /// does not: its keys name a dependency *or* `julia`, and nothing here
+    /// resolves the latter.
+    #[test]
+    fn dep_entries_cover_the_three_dependency_tables() {
+        let entries: Vec<(String, DepTable)> = dep_entries(TABLES)
+            .into_iter()
+            .map(|entry| (entry.name, entry.table))
+            .collect();
+        assert_eq!(
+            entries,
+            vec![
+                ("AbstractTrees".to_string(), DepTable::Deps),
+                ("JSON".to_string(), DepTable::Deps),
+                ("Plots".to_string(), DepTable::WeakDeps),
+                ("Test".to_string(), DepTable::Extras),
+            ],
+            "in source order, and no `[compat]` key"
+        );
+    }
+
+    #[test]
+    fn a_dep_entry_spans_its_name_and_its_uuid() {
+        let entries = dep_entries(TABLES);
+        let trees = entries.first().expect("the first entry");
+
+        assert_eq!(&TABLES[trees.name_range], "AbstractTrees");
+        // The value's span covers the quotes, as `uuid-mismatch` already relies on.
+        assert_eq!(
+            &TABLES[trees.uuid_range],
+            "\"1520ce14-60c1-5f80-bbc7-55ef81b5835c\""
+        );
+    }
+
+    /// Half-typed TOML must not produce a bogus jump. The file's own
+    /// `toml-syntax` finding is what reports the state it is in.
+    #[test]
+    fn a_project_file_that_does_not_parse_has_no_dep_entries() {
+        assert!(dep_entries("[deps\nAbstractTrees = \"x\"\n").is_empty());
+        assert_eq!(dep_at("[deps\nAbstractTrees = \"x\"\n", 8), None);
+    }
+
+    /// The name is the anchor every feature uses, so the hit test is the name
+    /// range and nothing else — both ends included, since an LSP position sits
+    /// *between* characters and a cursor just past the last one is still on it.
+    #[test]
+    fn dep_at_matches_the_name_and_nothing_else() {
+        let start = at(TABLES, "AbstractTrees");
+        let end = start + "AbstractTrees".len();
+
+        assert_eq!(
+            dep_at(TABLES, start).map(|d| d.name),
+            Some("AbstractTrees".into())
+        );
+        assert_eq!(
+            dep_at(TABLES, end - 1).map(|d| d.name),
+            Some("AbstractTrees".into())
+        );
+        assert_eq!(
+            dep_at(TABLES, end).map(|d| d.name),
+            Some("AbstractTrees".into())
+        );
+
+        // One past the name is the ` = `, and the UUID is a value, not a name.
+        assert_eq!(dep_at(TABLES, end + 1), None);
+        assert_eq!(dep_at(TABLES, at(TABLES, "1520ce14")), None);
+        // A `[compat]` key names no entry.
+        assert_eq!(dep_at(TABLES, at(TABLES, "julia = ")), None);
+    }
+
+    #[test]
+    fn a_project_file_with_no_dependencies_has_no_entries() {
+        assert!(dep_entries("name = \"Demo\"\n\n[deps]\n").is_empty());
     }
 
     // --- The semantic checks ------------------------------------------------

--- a/tests/harvest.rs
+++ b/tests/harvest.rs
@@ -260,6 +260,7 @@ fn workspace_member_maps_files_to_host_modules() {
         roots: BTreeMap::from([("Pkg".to_string(), tmp.path().to_path_buf())]),
         workspaces: vec!["Pkg".to_string()],
         declared_deps: Default::default(),
+        project_files: Default::default(),
     };
 
     // A root-hosted file: empty host module path.
@@ -565,4 +566,23 @@ fn harvest_libraries_records_each_dev_packages_declared_deps() {
         ["LinearAlgebra"]
     );
     assert!(lib.declared_deps["PkgB"].is_empty());
+}
+
+#[test]
+fn harvest_libraries_records_each_dev_packages_project_file() {
+    use fatou::index::harvest_libraries;
+
+    let a = TempDir::new();
+    let b = TempDir::new();
+    write(&a.path().join("src/PkgA.jl"), "module PkgA\nend\n");
+    write(&b.path().join("src/PkgB.jl"), "module PkgB\nend\n");
+
+    let lib = harvest_libraries(&[package_env(a.path(), "PkgA"), package_env(b.path(), "PkgB")]);
+    assert_eq!(lib.project_files["PkgA"], a.path().join("Project.toml"));
+    assert_eq!(lib.project_files["PkgB"], b.path().join("Project.toml"));
+    assert_eq!(
+        lib.project_files.keys().collect::<Vec<_>>(),
+        lib.declared_deps.keys().collect::<Vec<_>>(),
+        "the two project-file maps must name the same packages"
+    );
 }

--- a/tests/harvest.rs
+++ b/tests/harvest.rs
@@ -261,6 +261,7 @@ fn workspace_member_maps_files_to_host_modules() {
         workspaces: vec!["Pkg".to_string()],
         declared_deps: Default::default(),
         project_files: Default::default(),
+        deps: Default::default(),
     };
 
     // A root-hosted file: empty host module path.

--- a/tests/harvest.rs
+++ b/tests/harvest.rs
@@ -490,6 +490,7 @@ fn package_env(dir: &Path, name: &str) -> fatou::environment::Environment {
         name: Some(name.to_string()),
         uuid: None,
         direct_deps: BTreeMap::new(),
+        declared_deps: Default::default(),
         packages: Vec::new(),
         depots: Vec::new(),
         source: fatou::environment::EnvSource::WorkspaceWalkUp,
@@ -544,18 +545,16 @@ fn harvest_libraries_merges_dev_packages_sorted() {
 
 #[test]
 fn harvest_libraries_records_each_dev_packages_declared_deps() {
-    use fatou::environment::Uuid;
     use fatou::index::harvest_libraries;
-    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
 
     let a = TempDir::new();
     let b = TempDir::new();
     write(&a.path().join("src/PkgA.jl"), "module PkgA\nend\n");
     write(&b.path().join("src/PkgB.jl"), "module PkgB\nend\n");
 
-    let uuid: Uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e".parse().unwrap();
     let mut env_a = package_env(a.path(), "PkgA");
-    env_a.direct_deps = BTreeMap::from([("LinearAlgebra".to_string(), uuid)]);
+    env_a.declared_deps = BTreeSet::from(["LinearAlgebra".to_string()]);
     // A folder with no declared dependencies still gets an (empty) entry: it
     // declares nothing, which is different from "we do not know".
     let env_b = package_env(b.path(), "PkgB");

--- a/tests/library_index.rs
+++ b/tests/library_index.rs
@@ -93,8 +93,13 @@ fn set_library_packages_replaces_whole_map() {
 }
 
 #[test]
-fn declared_deps_round_trip_and_survive_a_reharvest() {
-    use std::collections::{BTreeMap, BTreeSet};
+fn declared_deps_are_read_off_the_project_file_and_survive_a_reharvest() {
+    use std::collections::BTreeMap;
+
+    let project = TempFile::new(
+        "Project.toml",
+        "name = \"Foo\"\n\n[deps]\nLinearAlgebra = \"37e2e46d-f89d-539d-b4ee-838fcccc9c8e\"\nJSON3 = \"0f8b85d8-7281-11e9-16c2-39a750bddbf1\"\n",
+    );
 
     let mut db = IncrementalDatabase::new();
     assert!(
@@ -102,20 +107,55 @@ fn declared_deps_round_trip_and_survive_a_reharvest() {
         "no declared deps before any set"
     );
 
-    let deps: BTreeSet<String> = ["LinearAlgebra".to_string(), "JSON3".to_string()].into();
-    db.set_declared_deps(BTreeMap::from([("Foo".to_string(), Arc::new(deps))]));
+    db.set_project_files(BTreeMap::from([("Foo".to_string(), project.0.clone())]));
 
     let read = db.declared_deps("Foo").expect("Foo declares deps");
     assert!(read.contains("LinearAlgebra") && read.contains("JSON3"));
     // Visible through a read-only snapshot, which is what the linter holds.
     assert!(db.snapshot().declared_deps("Foo").is_some());
-    // A package with no declared set reads back `None`.
+    // A package with no project file reads back `None`.
     assert!(db.declared_deps("Bar").is_none());
 
     // The deps track the project files, not the harvest: re-harvesting a
     // package must not clear them.
     db.set_package_index("Foo", Arc::new(empty_package("Foo")));
     assert!(db.declared_deps("Foo").is_some(), "survives a re-harvest");
+}
+
+/// The project file is tracked text, so an editor's buffer is what the deps are
+/// read from — and registering the file again (a re-resolve) must not clobber
+/// that buffer with the stale disk copy.
+#[test]
+fn a_tracked_project_buffer_wins_over_the_disk_copy() {
+    use std::collections::BTreeMap;
+
+    let project = TempFile::new(
+        "Project.toml",
+        "[deps]\nJSON3 = \"0f8b85d8-7281-11e9-16c2-39a750bddbf1\"\n",
+    );
+    let registration = BTreeMap::from([("Foo".to_string(), project.0.clone())]);
+
+    let mut db = IncrementalDatabase::new();
+    db.upsert_file(
+        &project.0,
+        "[deps]\nJSON3 = \"0f8b85d8-7281-11e9-16c2-39a750bddbf1\"\nLinearAlgebra = \"37e2e46d-f89d-539d-b4ee-838fcccc9c8e\"\n"
+            .to_string(),
+    );
+    db.set_project_files(registration.clone());
+
+    let read = db.declared_deps("Foo").expect("Foo declares deps");
+    assert!(
+        read.contains("LinearAlgebra"),
+        "the unsaved buffer is what declares the dependency"
+    );
+
+    db.set_project_files(registration);
+    assert!(
+        db.declared_deps("Foo")
+            .expect("still declared")
+            .contains("LinearAlgebra"),
+        "re-registering must not revert the buffer to disk"
+    );
 }
 
 #[test]

--- a/tests/library_index.rs
+++ b/tests/library_index.rs
@@ -194,6 +194,54 @@ fn source_roots_round_trip_through_set_library() {
     assert!(db.package_root("Bar").is_none());
 }
 
+/// What the manifest pinned rides beside what the harvest found, and is set
+/// separately: either write may come first, and neither clears the other.
+/// A name the manifest pins but the harvest never indexed keeps its entry —
+/// that asymmetry is the reason the two maps are apart.
+#[test]
+fn dep_metadata_rides_beside_the_harvest() {
+    use fatou::environment::{PackageKind, PackageMeta};
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    let mut db = IncrementalDatabase::new();
+    assert!(db.package_meta("Foo").is_none(), "nothing before any set");
+
+    db.set_library_deps(BTreeMap::from([
+        (
+            "Foo".to_string(),
+            PackageMeta {
+                version: Some("0.4.5".to_string()),
+                kind: PackageKind::Registered,
+            },
+        ),
+        (
+            "Unfound".to_string(),
+            PackageMeta {
+                version: None,
+                kind: PackageKind::Stdlib,
+            },
+        ),
+    ]));
+
+    let mut packages = BTreeMap::new();
+    packages.insert("Foo".to_string(), Arc::new(empty_package("Foo")));
+    let mut roots = BTreeMap::new();
+    roots.insert("Foo".to_string(), PathBuf::from("/depot/Foo/abcde"));
+    db.set_library(packages, roots, Vec::new());
+
+    let meta = db.package_meta("Foo").expect("Foo's manifest entry");
+    assert_eq!(meta.version.as_deref(), Some("0.4.5"));
+    assert_eq!(meta.kind, PackageKind::Registered);
+    // A later harvest does not clear what the manifest pinned.
+    assert!(db.package_root("Foo").is_some());
+    // Pinned but never harvested: an entry here, none in the roots.
+    assert!(db.package_meta("Unfound").is_some());
+    assert!(db.package_root("Unfound").is_none());
+    // And visible through a read-only snapshot.
+    assert!(db.snapshot().package_meta("Foo").is_some());
+}
+
 #[test]
 fn set_library_packages_preserves_existing_roots() {
     use std::collections::BTreeMap;

--- a/tests/library_index.rs
+++ b/tests/library_index.rs
@@ -158,6 +158,48 @@ fn a_tracked_project_buffer_wins_over_the_disk_copy() {
     );
 }
 
+/// A `Project.toml` no workspace package claims — a `docs/Project.toml`, a
+/// depot one opened through a manifest link — is tracked like any other buffer
+/// once an editor opens it, but nothing reads its `[deps]`. The by-path lookup
+/// must say so: it is the language server's gate for whether a project-file
+/// keystroke changed anything, and an unclaimed file would otherwise re-lint
+/// the whole workspace on every character.
+#[test]
+fn an_unclaimed_project_file_declares_nothing() {
+    use std::collections::BTreeMap;
+
+    let claimed = TempFile::new(
+        "Project.toml",
+        "[deps]\nJSON3 = \"0f8b85d8-7281-11e9-16c2-39a750bddbf1\"\n",
+    );
+    let unclaimed = TempFile::new(
+        "Project.toml",
+        "[deps]\nLinearAlgebra = \"37e2e46d-f89d-539d-b4ee-838fcccc9c8e\"\n",
+    );
+
+    let mut db = IncrementalDatabase::new();
+    // Both are tracked; only one belongs to a workspace package.
+    db.upsert_file(
+        &unclaimed.0,
+        "[deps]\nLinearAlgebra = \"37e2e46d-f89d-539d-b4ee-838fcccc9c8e\"\n".to_string(),
+    );
+    db.set_project_files(BTreeMap::from([("Foo".to_string(), claimed.0.clone())]));
+
+    assert!(
+        db.declared_deps_of_file(&claimed.0).is_some(),
+        "the workspace package's own project file"
+    );
+    assert!(
+        db.declared_deps_of_file(&unclaimed.0).is_none(),
+        "tracked, but claimed by no package"
+    );
+    // An untracked path is not a project file of anyone's either.
+    assert!(
+        db.declared_deps_of_file(std::path::Path::new("/nowhere/Project.toml"))
+            .is_none()
+    );
+}
+
 #[test]
 fn snapshot_reads_the_library() {
     let mut db = IncrementalDatabase::new();

--- a/tests/lint_workspace.rs
+++ b/tests/lint_workspace.rs
@@ -74,6 +74,7 @@ fn project(b_contents: &str) -> (TempDir, TempDir, HarvestedLibrary) {
         roots: BTreeMap::from([("M".to_string(), pkg.path().to_path_buf())]),
         workspaces: vec!["M".to_string()],
         declared_deps: Default::default(),
+        project_files: Default::default(),
     };
     (dep, pkg, library)
 }
@@ -144,6 +145,7 @@ fn project_with_deps() -> (TempDir, HarvestedLibrary) {
             "M".to_string(),
             Arc::new(["SparseArrays".to_string()].into_iter().collect()),
         )]),
+        project_files: Default::default(),
     };
     (pkg, library)
 }

--- a/tests/lint_workspace.rs
+++ b/tests/lint_workspace.rs
@@ -75,6 +75,7 @@ fn project(b_contents: &str) -> (TempDir, TempDir, HarvestedLibrary) {
         workspaces: vec!["M".to_string()],
         declared_deps: Default::default(),
         project_files: Default::default(),
+        deps: Default::default(),
     };
     (dep, pkg, library)
 }
@@ -146,6 +147,7 @@ fn project_with_deps() -> (TempDir, HarvestedLibrary) {
             Arc::new(["SparseArrays".to_string()].into_iter().collect()),
         )]),
         project_files: Default::default(),
+        deps: Default::default(),
     };
     (pkg, library)
 }

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -21,17 +21,18 @@ use lsp_types::{
     DocumentLinkParams, DocumentRangeFormattingParams, DocumentSymbol, DocumentSymbolParams,
     FileChangeType, FileEvent, FileRename, FoldingRange, FoldingRangeKind, FoldingRangeParams,
     FormattingOptions, GeneralClientCapabilities, GlobPattern, GotoDefinitionParams,
-    GotoDefinitionResponse, Hover, HoverContents, HoverParams, InitializeParams, Location,
-    NumberOrString, PartialResultParams, Position, PositionEncodingKind, ProgressParams,
-    ProgressParamsValue, PublishDiagnosticsParams, Range, ReferenceContext, ReferenceParams,
-    RegistrationParams, RenameFilesParams, RenameParams, SelectionRange, SelectionRangeParams,
-    SemanticTokens, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
-    SignatureHelp, SignatureHelpParams, SymbolKind, TextDocumentContentChangeEvent,
-    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, TextEdit,
-    TypeHierarchyItem, TypeHierarchyPrepareParams, TypeHierarchySubtypesParams,
-    TypeHierarchySupertypesParams, Uri, VersionedTextDocumentIdentifier, WindowClientCapabilities,
-    WorkDoneProgress, WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceEdit,
-    WorkspaceFolder, WorkspaceSymbolParams, WorkspaceSymbolResponse,
+    GotoDefinitionResponse, Hover, HoverContents, HoverParams, InitializeParams, InlayHint,
+    InlayHintLabel, InlayHintParams, Location, NumberOrString, PartialResultParams, Position,
+    PositionEncodingKind, ProgressParams, ProgressParamsValue, PublishDiagnosticsParams, Range,
+    ReferenceContext, ReferenceParams, RegistrationParams, RenameFilesParams, RenameParams,
+    SelectionRange, SelectionRangeParams, SemanticTokens, SemanticTokensDeltaParams,
+    SemanticTokensFullDeltaResult, SemanticTokensParams, SignatureHelp, SignatureHelpParams,
+    SymbolKind, TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, TextEdit, TypeHierarchyItem, TypeHierarchyPrepareParams,
+    TypeHierarchySubtypesParams, TypeHierarchySupertypesParams, Uri,
+    VersionedTextDocumentIdentifier, WindowClientCapabilities, WorkDoneProgress,
+    WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceEdit, WorkspaceFolder,
+    WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -5299,7 +5300,7 @@ fn write_pkg_with_path_dep(prefix: &str) -> TempDir {
         &root.path.join("MyPkg/Manifest.toml"),
         &format!(
             "manifest_format = \"2.0\"\n\n[[deps.Greetings]]\n\
-             uuid = \"{GREETINGS}\"\npath = \"../Greetings\"\n"
+             uuid = \"{GREETINGS}\"\nversion = \"0.4.5\"\npath = \"../Greetings\"\n"
         ),
     );
     write_file(&root.path.join("MyPkg/src/MyPkg.jl"), "module MyPkg\nend\n");
@@ -5438,7 +5439,7 @@ fn serves_navigation_on_a_dependency_name() {
     assert_eq!(
         markup.value,
         format!(
-            "**Greetings**\n\nDevelopment dependency\n\n`{}`",
+            "**Greetings** v0.4.5\n\nDevelopment dependency\n\n`{}`",
             dep_root.display()
         ),
     );
@@ -5472,6 +5473,39 @@ fn serves_navigation_on_a_dependency_name() {
             Some(file_uri(&entry).as_str()),
         )],
         "only the [deps] name links; [compat] names no package to link to"
+    );
+
+    // The resolved version also shows as an inlay hint, after the UUID: the
+    // `[deps]` table is otherwise pure UUID, and the version lives next door in
+    // the manifest.
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(617),
+            method: "textDocument/inlayHint".to_string(),
+            params: serde_json::to_value(InlayHintParams {
+                text_document: TextDocumentIdentifier {
+                    uri: project_uri.clone(),
+                },
+                range: Range::new(Position::new(0, 0), Position::new(line + 1, 0)),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    let resp = recv_response(&client, RequestId::from(617));
+    let hints: Vec<InlayHint> = serde_json::from_value(resp.result().unwrap()).unwrap();
+    let [hint] = &hints[..] else {
+        panic!("expected exactly one inlay hint, got {hints:?}");
+    };
+    let InlayHintLabel::String(label) = &hint.label else {
+        panic!("expected a plain string label");
+    };
+    assert_eq!(label, "v0.4.5", "the manifest's version, shown inline");
+    let deps_line = text.lines().nth(line as usize).unwrap();
+    assert_eq!(
+        hint.position,
+        Position::new(line, u32::try_from(deps_line.len()).unwrap()),
     );
 
     // Nothing else in the file jumps: a `[compat]` key names a dependency too,

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5273,6 +5273,187 @@ fn an_unsaved_project_file_edit_clears_unresolved_import() {
     server_thread.join().unwrap();
 }
 
+/// Write a workspace holding `MyPkg` and a dependency it can resolve with no
+/// depot at all: the manifest pins `Greetings` by `path`, so the harvester
+/// indexes it straight off disk. Returns the temp root; the project directory
+/// is `<root>/MyPkg`.
+fn write_pkg_with_path_dep(prefix: &str) -> TempDir {
+    const GREETINGS: &str = "00000000-0000-0000-0000-0000000000e0";
+    let root = TempDir::new(prefix);
+    write_file(
+        &root.path.join("Greetings/Project.toml"),
+        &format!("name = \"Greetings\"\nuuid = \"{GREETINGS}\"\n"),
+    );
+    write_file(
+        &root.path.join("Greetings/src/Greetings.jl"),
+        "module Greetings\ngreet(a) = a\nend\n",
+    );
+    write_file(
+        &root.path.join("MyPkg/Project.toml"),
+        &format!(
+            "name = \"MyPkg\"\nuuid = \"00000000-0000-0000-0000-000000000001\"\n\n\
+             [deps]\nGreetings = \"{GREETINGS}\"\n\n[compat]\njulia = \"1.10\"\nGreetings = \"1\"\n"
+        ),
+    );
+    write_file(
+        &root.path.join("MyPkg/Manifest.toml"),
+        &format!(
+            "manifest_format = \"2.0\"\n\n[[deps.Greetings]]\n\
+             uuid = \"{GREETINGS}\"\npath = \"../Greetings\"\n"
+        ),
+    );
+    write_file(&root.path.join("MyPkg/src/MyPkg.jl"), "module MyPkg\nend\n");
+    root
+}
+
+/// Poll `textDocument/definition` at `position` until it answers something, or
+/// the deadline passes. The library index arrives with the harvest, well after
+/// the handshake, so the first request legitimately answers `null`.
+fn poll_definition(
+    client: &Connection,
+    uri: &Uri,
+    position: Position,
+    deadline: Duration,
+) -> Location {
+    static POLL_ID: AtomicU64 = AtomicU64::new(600);
+    let start = Instant::now();
+    loop {
+        let id = i32::try_from(POLL_ID.fetch_add(1, Ordering::Relaxed)).unwrap();
+        client
+            .sender
+            .send(Message::Request(Request {
+                id: RequestId::from(id),
+                method: "textDocument/definition".to_string(),
+                params: serde_json::to_value(GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier { uri: uri.clone() },
+                        position,
+                    },
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                })
+                .unwrap(),
+            }))
+            .unwrap();
+        let resp = recv_response(client, RequestId::from(id));
+        let result = resp.result().expect("a definition result");
+        if !result.is_null() {
+            return serde_json::from_value(result).expect("a single location");
+        }
+        assert!(
+            start.elapsed() < deadline,
+            "definition never resolved within {deadline:?} — the harvest likely failed"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Go-to-definition on a `[deps]` name in an open `Project.toml` lands on the
+/// dependency's entry file. The whole point of stage 4: the environment files
+/// are in the client's document selector, so a request arrives for one, and a
+/// dependency name is something the server can resolve.
+#[test]
+fn serves_go_to_definition_on_a_dependency_name() {
+    let _env = ENV_LOCK.lock().unwrap();
+
+    let root = write_pkg_with_path_dep("fatou-lsp-depdef");
+    let pkg_dir = root.path.join("MyPkg");
+    let depot = TempDir::new("fatou-lsp-depdef-depot");
+    let _guard = EnvGuard::set(&[
+        ("JULIA_PROJECT", pkg_dir.to_str().unwrap()),
+        ("JULIA_DEPOT_PATH", depot.path.to_str().unwrap()),
+        ("JULIA_BINDIR", ""),
+        ("PATH", ""),
+        ("HOME", depot.path.to_str().unwrap()),
+    ]);
+
+    let (server, client) = Connection::memory();
+    let server_thread = std::thread::spawn(move || {
+        fatou::lsp::serve(&server).expect("server loop");
+    });
+    initialize_with_root(&client, &file_uri(&pkg_dir));
+
+    let project = pkg_dir.join("Project.toml");
+    let project_uri = file_uri(&project);
+    let text = std::fs::read_to_string(&project).unwrap();
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didOpen".to_string(),
+            params: serde_json::to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: project_uri.clone(),
+                    language_id: "toml".to_string(),
+                    version: 1,
+                    text: text.clone(),
+                },
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+
+    // The `Greetings` key of `[deps]`, wherever the fixture happens to put it.
+    let offset = text.find("Greetings = ").unwrap();
+    let line = u32::try_from(text[..offset].matches('\n').count()).unwrap();
+    let location = poll_definition(
+        &client,
+        &project_uri,
+        Position::new(line, 2),
+        Duration::from_secs(10),
+    );
+
+    let entry = root.path.join("Greetings/src/Greetings.jl");
+    assert_eq!(location.uri.as_str(), file_uri(&entry).as_str());
+    // The `Greetings` of `module Greetings`, line 0, columns 7..16.
+    assert_eq!(
+        location.range,
+        Range::new(Position::new(0, 7), Position::new(0, 16)),
+    );
+
+    // Nothing else in the file jumps: a `[compat]` key names a dependency too,
+    // but resolving it is not this feature.
+    let compat = text.rfind("Greetings = ").unwrap();
+    let compat_line = u32::try_from(text[..compat].matches('\n').count()).unwrap();
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(620),
+            method: "textDocument/definition".to_string(),
+            params: serde_json::to_value(GotoDefinitionParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: project_uri.clone(),
+                    },
+                    position: Position::new(compat_line, 2),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    let resp = recv_response(&client, RequestId::from(620));
+    assert_eq!(resp.result(), Some(serde_json::Value::Null));
+
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(621),
+            method: "shutdown".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    let _ = recv_response(&client, RequestId::from(621));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "exit".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    server_thread.join().unwrap();
+}
+
 /// Two workspace folders, each its own package project, driven end-to-end:
 /// both harvest, cross-file references stay inside the folder that owns the
 /// cursor (the other folder defines a same-named `greet`), and workspace

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5031,6 +5031,139 @@ fn publishes_and_clears_project_file_syntax_diagnostics() {
     server_thread.join().unwrap();
 }
 
+/// The prize of making the project file a live input: adding a name to
+/// `[deps]` in an editor buffer clears `unresolved-import` across the package
+/// with **no save and no watched-file event**. Nothing here writes the project
+/// file back to disk — only `didOpen`/`didChange` carry the new text — so a
+/// pass proves the buffer, not the disk copy, is what the linter reads.
+///
+/// It doubles as the end-to-end check that a push client is refreshed at all:
+/// the finding itself only appears once the harvest lands, which is a moment
+/// no edit of the Julia buffer marks.
+#[test]
+fn an_unsaved_project_file_edit_clears_unresolved_import() {
+    let _env = ENV_LOCK.lock().unwrap();
+
+    let pkg = TempDir::new("fatou-lsp-livedeps");
+    let project = pkg.path.join("Project.toml");
+    let on_disk = "name = \"MyPkg\"\nuuid = \"00000000-0000-0000-0000-000000000001\"\n\n[compat]\njulia = \"1.10\"\n";
+    write_file(&project, on_disk);
+    write_file(
+        &pkg.path.join("src/MyPkg.jl"),
+        "module MyPkg\nusing Foo\nend\n",
+    );
+
+    let depot = TempDir::new("fatou-lsp-livedeps-depot");
+    let _guard = EnvGuard::set(&[
+        ("JULIA_PROJECT", pkg.path.to_str().unwrap()),
+        ("JULIA_DEPOT_PATH", depot.path.to_str().unwrap()),
+        ("JULIA_BINDIR", ""),
+        ("PATH", ""),
+        ("HOME", depot.path.to_str().unwrap()),
+    ]);
+
+    let (server, client) = Connection::memory();
+    let server_thread = std::thread::spawn(move || {
+        fatou::lsp::serve(&server).expect("server loop");
+    });
+    initialize_with_root(&client, &file_uri(&pkg.path));
+
+    let source_uri = file_uri(&pkg.path.join("src/MyPkg.jl"));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didOpen".to_string(),
+            params: serde_json::to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: source_uri.clone(),
+                    language_id: "julia".to_string(),
+                    version: 1,
+                    text: "module MyPkg\nusing Foo\nend\n".to_string(),
+                },
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+
+    // `Foo` is neither declared nor installed. The finding needs the harvest,
+    // which lands well after the buffer's own analysis.
+    let diags = poll_publish_where(&client, "MyPkg.jl", Duration::from_secs(10), |diags| {
+        diags
+            .iter()
+            .any(|d| d.code == Some(NumberOrString::String("unresolved-import".to_string())))
+    });
+    assert!(diags.iter().any(|d| d.message.contains("Foo")), "{diags:?}");
+
+    // The project file opened and edited, never saved.
+    let project_uri = file_uri(&project);
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didOpen".to_string(),
+            params: serde_json::to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: project_uri.clone(),
+                    language_id: "toml".to_string(),
+                    version: 1,
+                    text: on_disk.to_string(),
+                },
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didChange".to_string(),
+            params: serde_json::to_value(DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: project_uri,
+                    version: 2,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: format!(
+                        "{on_disk}\n[deps]\nFoo = \"00000000-0000-0000-0000-0000000000f0\"\n"
+                    ),
+                }],
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+
+    let cleared = poll_publish_where(
+        &client,
+        "MyPkg.jl",
+        Duration::from_secs(10),
+        <[_]>::is_empty,
+    );
+    assert!(cleared.is_empty());
+    assert_eq!(
+        std::fs::read_to_string(&project).unwrap(),
+        on_disk,
+        "witness: the file on disk still declares nothing"
+    );
+
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(311),
+            method: "shutdown".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    let _ = recv_response(&client, RequestId::from(311));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "exit".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    server_thread.join().unwrap();
+}
+
 /// Two workspace folders, each its own package project, driven end-to-end:
 /// both harvest, cross-file references stay inside the folder that owns the
 /// cursor (the other folder defines a same-named `greet`), and workspace

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5031,6 +5031,115 @@ fn publishes_and_clears_project_file_syntax_diagnostics() {
     server_thread.join().unwrap();
 }
 
+/// An open `Project.toml` reports its own TOML errors from the *buffer*, at
+/// edit cadence: the error appears on the keystroke that introduces it and
+/// clears on the one that fixes it, with no save, no watched-file event, and —
+/// no workspace folder here — no harvester at all. The second half is the
+/// other side of making it a real document: a language feature must answer
+/// nothing for it, rather than parsing TOML as Julia.
+#[test]
+fn publishes_project_file_diagnostics_from_the_open_buffer() {
+    let (server, client) = Connection::memory();
+    let server_thread = std::thread::spawn(move || {
+        fatou::lsp::serve(&server).expect("server loop");
+    });
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(1),
+            method: "initialize".to_string(),
+            params: serde_json::to_value(InitializeParams::default()).unwrap(),
+        }))
+        .unwrap();
+    let _ = recv_response(&client, RequestId::from(1));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "initialized".to_string(),
+            params: serde_json::json!({}),
+        }))
+        .unwrap();
+
+    let project = native_file_uri("/work/Project.toml");
+    open_document(&client, &project, "name = \"MyPkg\"\n");
+    // Broken by an edit that is never saved.
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didChange".to_string(),
+            params: serde_json::to_value(DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: project.clone(),
+                    version: 2,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "name = \"MyPkg\"\nuuid = \n".to_string(),
+                }],
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+
+    let published = recv_publish_for(&client, &project);
+    let [diag] = &published.diagnostics[..] else {
+        panic!("expected one diagnostic, got {published:?}");
+    };
+    assert_eq!(
+        diag.code,
+        Some(NumberOrString::String("toml-syntax".to_string()))
+    );
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(diag.range.start.line, 1, "the `uuid = ` line");
+    assert_eq!(published.version, Some(2));
+
+    // A language feature answers nothing for it: a formatting request would
+    // otherwise reformat TOML as Julia.
+    assert_eq!(format_document(&client, &project, 2), None);
+
+    // Fixed, still unsaved: the file clears.
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didChange".to_string(),
+            params: serde_json::to_value(DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: project.clone(),
+                    version: 3,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "name = \"MyPkg\"\nuuid = \"00000000-0000-0000-0000-000000000001\"\n"
+                        .to_string(),
+                }],
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    let cleared = recv_publish_for(&client, &project);
+    assert!(cleared.diagnostics.is_empty(), "{cleared:?}");
+
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(3),
+            method: "shutdown".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    let _ = recv_response(&client, RequestId::from(3));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "exit".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    server_thread.join().unwrap();
+}
+
 /// The prize of making the project file a live input: adding a name to
 /// `[deps]` in an editor buffer clears `unresolved-import` across the package
 /// with **no save and no watched-file event**. Nothing here writes the project

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5274,6 +5274,110 @@ fn an_unsaved_project_file_edit_clears_unresolved_import() {
     server_thread.join().unwrap();
 }
 
+/// The mirror of the test above, and the case the *unsaved* buffer must not
+/// cost: a `Project.toml` changed **on disk with no buffer at all** — `pkg>
+/// add` from a terminal, a branch switch — must reach `unresolved-import` too.
+///
+/// The declared dependencies are read off the file's tracked salsa input, and
+/// the re-resolve a watched environment event triggers cannot refresh it
+/// (`set_project_files` is create-or-return, so an open buffer survives one).
+/// The watched-file sync is what does, and this is its guard: without it the
+/// lint answers to the text the file had when the server first harvested it,
+/// for the rest of the session.
+#[test]
+fn a_watched_project_file_change_clears_unresolved_import() {
+    let _env = ENV_LOCK.lock().unwrap();
+
+    let pkg = TempDir::new("fatou-lsp-watcheddeps");
+    let project = pkg.path.join("Project.toml");
+    let on_disk = "name = \"MyPkg\"\nuuid = \"00000000-0000-0000-0000-000000000001\"\n\n[compat]\njulia = \"1.10\"\n";
+    write_file(&project, on_disk);
+    write_file(
+        &pkg.path.join("src/MyPkg.jl"),
+        "module MyPkg\nusing Foo\nend\n",
+    );
+
+    let depot = TempDir::new("fatou-lsp-watcheddeps-depot");
+    let _guard = EnvGuard::set(&[
+        ("JULIA_PROJECT", pkg.path.to_str().unwrap()),
+        ("JULIA_DEPOT_PATH", depot.path.to_str().unwrap()),
+        ("JULIA_BINDIR", ""),
+        ("PATH", ""),
+        ("HOME", depot.path.to_str().unwrap()),
+    ]);
+
+    let (server, client) = Connection::memory();
+    let server_thread = std::thread::spawn(move || {
+        fatou::lsp::serve(&server).expect("server loop");
+    });
+    initialize_with_root(&client, &file_uri(&pkg.path));
+
+    let source_uri = file_uri(&pkg.path.join("src/MyPkg.jl"));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didOpen".to_string(),
+            params: serde_json::to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: source_uri,
+                    language_id: "julia".to_string(),
+                    version: 1,
+                    text: "module MyPkg\nusing Foo\nend\n".to_string(),
+                },
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+
+    // `Foo` is neither declared nor installed; the finding needs the harvest.
+    let diags = poll_publish_where(&client, "MyPkg.jl", Duration::from_secs(10), |diags| {
+        diags
+            .iter()
+            .any(|d| d.code == Some(NumberOrString::String("unresolved-import".to_string())))
+    });
+    assert!(diags.iter().any(|d| d.message.contains("Foo")), "{diags:?}");
+
+    // `pkg> add Foo`, from outside the editor: the file changes on disk and the
+    // watcher reports it. Nothing ever opened it.
+    write_file(
+        &project,
+        &format!("{on_disk}\n[deps]\nFoo = \"00000000-0000-0000-0000-0000000000f0\"\n"),
+    );
+    did_change_watched_files(
+        &client,
+        vec![FileEvent {
+            uri: file_uri(&project),
+            typ: FileChangeType::CHANGED,
+        }],
+    );
+
+    let cleared = poll_publish_where(
+        &client,
+        "MyPkg.jl",
+        Duration::from_secs(10),
+        <[_]>::is_empty,
+    );
+    assert!(cleared.is_empty());
+
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(313),
+            method: "shutdown".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    let _ = recv_response(&client, RequestId::from(313));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "exit".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    server_thread.join().unwrap();
+}
+
 /// Write a workspace holding `MyPkg` and a dependency it can resolve with no
 /// depot at all: the manifest pins `Greetings` by `path`, so the harvester
 /// indexes it straight off disk. Returns the temp root; the project directory

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5348,12 +5348,12 @@ fn poll_definition(
     }
 }
 
-/// Go-to-definition on a `[deps]` name in an open `Project.toml` lands on the
-/// dependency's entry file. The whole point of stage 4: the environment files
-/// are in the client's document selector, so a request arrives for one, and a
-/// dependency name is something the server can resolve.
+/// Go-to-definition and hover on a `[deps]` name in an open `Project.toml`:
+/// the jump lands on the dependency's entry file, the hover reports what the
+/// environment resolved it to. Both ride the same route, so one initialized
+/// server covers them — and the `JULIA_*` env is process-global anyway.
 #[test]
-fn serves_go_to_definition_on_a_dependency_name() {
+fn serves_navigation_on_a_dependency_name() {
     let _env = ENV_LOCK.lock().unwrap();
 
     let root = write_pkg_with_path_dep("fatou-lsp-depdef");
@@ -5408,6 +5408,39 @@ fn serves_go_to_definition_on_a_dependency_name() {
     assert_eq!(
         location.range,
         Range::new(Position::new(0, 7), Position::new(0, 16)),
+    );
+
+    // Hover on the same name reports what the environment resolved it to. It
+    // rides the same route, so one initialized server covers both.
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(619),
+            method: "textDocument/hover".to_string(),
+            params: serde_json::to_value(HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: project_uri.clone(),
+                    },
+                    position: Position::new(line, 2),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    let resp = recv_response(&client, RequestId::from(619));
+    let hover: Hover = serde_json::from_value(resp.result().unwrap()).unwrap();
+    let HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected markdown hover contents");
+    };
+    let dep_root = root.path.join("Greetings");
+    assert_eq!(
+        markup.value,
+        format!(
+            "**Greetings**\n\nDevelopment dependency\n\n`{}`",
+            dep_root.display()
+        ),
     );
 
     // Nothing else in the file jumps: a `[compat]` key names a dependency too,

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5378,6 +5378,116 @@ fn a_watched_project_file_change_clears_unresolved_import() {
     server_thread.join().unwrap();
 }
 
+/// A `Project.toml` open at startup shows a bare UUID until something tells the
+/// client to ask again: the versions its inlay hints report arrive with the
+/// harvest, seconds after `initialize`, and a client re-requests hints only on
+/// an edit or a scroll. `workspace/inlayHint/refresh` is that something.
+#[test]
+fn a_landed_harvest_refreshes_inlay_hints() {
+    let _env = ENV_LOCK.lock().unwrap();
+
+    let root = write_pkg_with_path_dep("fatou-lsp-hintrefresh");
+    let pkg_dir = root.path.join("MyPkg");
+    let depot = TempDir::new("fatou-lsp-hintrefresh-depot");
+    let _guard = EnvGuard::set(&[
+        ("JULIA_PROJECT", pkg_dir.to_str().unwrap()),
+        ("JULIA_DEPOT_PATH", depot.path.to_str().unwrap()),
+        ("JULIA_BINDIR", ""),
+        ("PATH", ""),
+        ("HOME", depot.path.to_str().unwrap()),
+    ]);
+
+    let (server, client) = Connection::memory();
+    let server_thread = std::thread::spawn(move || {
+        fatou::lsp::serve(&server).expect("server loop");
+    });
+
+    #[allow(deprecated)]
+    let params = InitializeParams {
+        root_uri: Some(file_uri(&pkg_dir)),
+        capabilities: ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                inlay_hint: Some(lsp_types::InlayHintWorkspaceClientCapabilities {
+                    refresh_support: Some(true),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(1),
+            method: "initialize".to_string(),
+            params: serde_json::to_value(params).unwrap(),
+        }))
+        .unwrap();
+    assert!(matches!(
+        client.receiver.recv().unwrap(),
+        Message::Response(_)
+    ));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "initialized".to_string(),
+            params: serde_json::json!({}),
+        }))
+        .unwrap();
+
+    // Opened before the harvest lands, which is the whole point: at this moment
+    // the server knows no versions and the hints would be empty.
+    let project = pkg_dir.join("Project.toml");
+    let project_uri = file_uri(&project);
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didOpen".to_string(),
+            params: serde_json::to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: project_uri,
+                    language_id: "toml".to_string(),
+                    version: 1,
+                    text: std::fs::read_to_string(&project).unwrap(),
+                },
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+
+    // Bounded, so a missing nudge fails rather than hangs.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let refresh = loop {
+        let left = deadline.saturating_duration_since(Instant::now());
+        assert!(!left.is_zero(), "no inlay hint refresh within 10s");
+        match client.receiver.recv_timeout(left) {
+            Ok(Message::Request(req)) if req.method == "workspace/inlayHint/refresh" => break req,
+            Ok(_) => continue,
+            Err(_) => panic!("no inlay hint refresh within 10s"),
+        }
+    };
+    assert_eq!(refresh.params, serde_json::Value::Null);
+
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(631),
+            method: "shutdown".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    let _ = recv_response(&client, RequestId::from(631));
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "exit".to_string(),
+            params: serde_json::Value::Null,
+        }))
+        .unwrap();
+    server_thread.join().unwrap();
+}
+
 /// Write a workspace holding `MyPkg` and a dependency it can resolve with no
 /// depot at all: the manifest pins `Greetings` by `path`, so the harvester
 /// indexes it straight off disk. Returns the temp root; the project directory

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5443,6 +5443,37 @@ fn serves_navigation_on_a_dependency_name() {
         ),
     );
 
+    // And the name is a document link to the same file, so a client underlines
+    // it without a cursor ever landing there.
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(618),
+            method: "textDocument/documentLink".to_string(),
+            params: serde_json::to_value(DocumentLinkParams {
+                text_document: TextDocumentIdentifier {
+                    uri: project_uri.clone(),
+                },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    let resp = recv_response(&client, RequestId::from(618));
+    let links: Vec<DocumentLink> = serde_json::from_value(resp.result().unwrap()).unwrap();
+    assert_eq!(
+        links
+            .iter()
+            .map(|link| (link.range, link.target.as_ref().map(|uri| uri.as_str())))
+            .collect::<Vec<_>>(),
+        vec![(
+            Range::new(Position::new(line, 0), Position::new(line, 9)),
+            Some(file_uri(&entry).as_str()),
+        )],
+        "only the [deps] name links; [compat] names no package to link to"
+    );
+
     // Nothing else in the file jumps: a `[compat]` key names a dependency too,
     // but resolving it is not this feature.
     let compat = text.rfind("Greetings = ").unwrap();

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -5533,6 +5533,65 @@ fn serves_navigation_on_a_dependency_name() {
     let resp = recv_response(&client, RequestId::from(620));
     assert_eq!(resp.result(), Some(serde_json::Value::Null));
 
+    // The manifest next door answers one feature of its own: each `path` entry
+    // is a link to the `dev`'d package it pins — that root's project file,
+    // since a client cannot open a directory. It rides no harvest, so unlike
+    // the jump above it needs no polling.
+    let manifest = pkg_dir.join("Manifest.toml");
+    let manifest_uri = file_uri(&manifest);
+    let manifest_text = std::fs::read_to_string(&manifest).unwrap();
+    client
+        .sender
+        .send(Message::Notification(Notification {
+            method: "textDocument/didOpen".to_string(),
+            params: serde_json::to_value(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: manifest_uri.clone(),
+                    language_id: "toml".to_string(),
+                    version: 1,
+                    text: manifest_text.clone(),
+                },
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    client
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(622),
+            method: "textDocument/documentLink".to_string(),
+            params: serde_json::to_value(DocumentLinkParams {
+                text_document: TextDocumentIdentifier {
+                    uri: manifest_uri.clone(),
+                },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .unwrap(),
+        }))
+        .unwrap();
+    let resp = recv_response(&client, RequestId::from(622));
+    let links: Vec<DocumentLink> = serde_json::from_value(resp.result().unwrap()).unwrap();
+    // The path text, quotes excluded, wherever the fixture put it.
+    let at = manifest_text.find("\"../Greetings\"").unwrap() + 1;
+    let path_line = u32::try_from(manifest_text[..at].matches('\n').count()).unwrap();
+    let column =
+        u32::try_from(at - manifest_text[..at].rfind('\n').map_or(0, |nl| nl + 1)).unwrap();
+    assert_eq!(
+        links
+            .iter()
+            .map(|link| (link.range, link.target.as_ref().map(|uri| uri.as_str())))
+            .collect::<Vec<_>>(),
+        vec![(
+            Range::new(
+                Position::new(path_line, column),
+                Position::new(path_line, column + 12),
+            ),
+            Some(file_uri(&root.path.join("Greetings/Project.toml")).as_str()),
+        )],
+        "the `../Greetings` spelling collapses, and the link lands on a file"
+    );
+
     client
         .sender
         .send(Message::Request(Request {

--- a/tests/parallel_harvest.rs
+++ b/tests/parallel_harvest.rs
@@ -56,6 +56,7 @@ fn env_with(packages: Vec<Package>) -> Environment {
         name: None,
         uuid: None,
         direct_deps: BTreeMap::new(),
+        declared_deps: Default::default(),
         packages,
         depots: Vec::new(),
         source: EnvSource::DefaultEnv,

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -3,7 +3,7 @@
 use fatou::incremental::{
     IncrementalDatabase, IncrementalDb, PrevParse, SourceFile, control_flow, file_exports,
     file_free_reads, file_qualified_reads, host_module_of, include_edges, parse_diagnostics,
-    parsed_tree_root, project_graph, semantic_model,
+    parsed_tree_root, project_declared_deps, project_graph, semantic_model,
 };
 use fatou::parser::{Edit, apply_edits, parse};
 
@@ -494,6 +494,176 @@ firewall_backdates_test!(
     "k() = 1\ninclude(\"a.jl\")\n",
     "k() = 111\ninclude(\"a.jl\")\n"
 );
+
+/// The probes for the project-file firewall: a `Project.toml` edit must reach
+/// the declared dependencies and nothing else. `parsed_document` is `no_eq`, so
+/// a parse that re-executed would force `probe_parse` to re-run — a counter
+/// resting at 1 is a sound witness that it did not.
+#[salsa::tracked(returns(copy))]
+fn probe_parse(db: &dyn IncrementalDb, file: SourceFile) -> usize {
+    use std::sync::atomic::Ordering;
+    PARSE_PROBE_RUNS.fetch_add(1, Ordering::SeqCst);
+    parse_diagnostics(db, file).len()
+}
+
+static PARSE_PROBE_RUNS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[salsa::tracked(returns(copy))]
+fn probe_graph(db: &dyn IncrementalDb) -> usize {
+    use std::sync::atomic::Ordering;
+    GRAPH_PROBE_RUNS.fetch_add(1, Ordering::SeqCst);
+    project_graph(db).nodes.len()
+}
+
+static GRAPH_PROBE_RUNS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// A one-member workspace package with its project file tracked as an input,
+/// returned as `(db, entry, project)`.
+fn project_db(project_text: &str) -> (IncrementalDatabase, SourceFile, SourceFile) {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    use fatou::index::model::{DefLocation, Span};
+    use fatou::index::{ModuleIndex, PackageIndex};
+
+    let pkg = PackageIndex {
+        name: "MyPkg".to_string(),
+        root: ModuleIndex {
+            name: "MyPkg".to_string(),
+            bare: false,
+            loc: DefLocation {
+                file: "src/MyPkg.jl".into(),
+                range: Span { start: 0, end: 0 },
+            },
+            exports: Vec::new(),
+            functions: Vec::new(),
+            types: Vec::new(),
+            consts: Vec::new(),
+            macros: Vec::new(),
+            submodules: Vec::new(),
+            usings: Vec::new(),
+            imported_names: Vec::new(),
+        },
+        members: Vec::new(),
+        member_modules: Default::default(),
+        diagnostics: Vec::new(),
+    };
+
+    let mut db = IncrementalDatabase::new();
+    let entry = db.upsert_file(
+        Path::new("/work/MyPkg/src/MyPkg.jl"),
+        "module MyPkg\nk() = 1\nend\n".to_string(),
+    );
+    // Tracked before `set_project_files`, which is create-or-return: the input
+    // stands in for an open editor buffer that never touched disk.
+    let project = db.upsert_file(
+        Path::new("/work/MyPkg/Project.toml"),
+        project_text.to_string(),
+    );
+
+    let mut packages = BTreeMap::new();
+    packages.insert("MyPkg".to_string(), Arc::new(pkg));
+    let mut roots = BTreeMap::new();
+    roots.insert("MyPkg".to_string(), PathBuf::from("/work/MyPkg"));
+    db.set_library(packages, roots, vec!["MyPkg".to_string()]);
+    db.set_workspace_files(vec![entry]);
+    db.set_project_files(BTreeMap::from([(
+        "MyPkg".to_string(),
+        PathBuf::from("/work/MyPkg/Project.toml"),
+    )]));
+    (db, entry, project)
+}
+
+fn declared(db: &IncrementalDatabase) -> Vec<String> {
+    db.declared_deps("MyPkg")
+        .map(|deps| deps.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// The mirror of the body-edit firewall, from the other side: a `Project.toml`
+/// edit must reach the resolution layer and leave the parses (and the include
+/// graph they feed) alone. Without this, making the project file a live input
+/// trades a body-edit firewall for a project-edit stampede.
+#[test]
+fn a_project_file_edit_invalidates_deps_but_not_parses() {
+    use std::sync::atomic::Ordering;
+
+    let (mut db, entry, project) =
+        project_db("[deps]\nFoo = \"11111111-2222-3333-4444-555555555555\"\n");
+
+    assert_eq!(probe_parse(&db, entry), 0);
+    let graph_before = probe_graph(&db);
+    assert_eq!(PARSE_PROBE_RUNS.load(Ordering::SeqCst), 1);
+    assert_eq!(GRAPH_PROBE_RUNS.load(Ordering::SeqCst), 1);
+    assert_eq!(declared(&db), ["Foo"]);
+
+    db.set_file_text(
+        project,
+        "[deps]\nFoo = \"11111111-2222-3333-4444-555555555555\"\nBar = \"66666666-7777-8888-9999-aaaaaaaaaaaa\"\n",
+    );
+
+    // Witness: the edit really landed on the resolution layer.
+    assert_eq!(declared(&db), ["Bar", "Foo"]);
+    assert_eq!(probe_parse(&db, entry), 0);
+    assert_eq!(probe_graph(&db), graph_before);
+    assert_eq!(
+        PARSE_PROBE_RUNS.load(Ordering::SeqCst),
+        1,
+        "a project-file edit must not re-parse a single Julia file"
+    );
+    assert_eq!(
+        GRAPH_PROBE_RUNS.load(Ordering::SeqCst),
+        1,
+        "a project-file edit must not re-derive the include graph"
+    );
+}
+
+/// A probe over the project file's own firewall, to observe backdating.
+#[salsa::tracked(returns(copy))]
+fn probe_deps(db: &dyn IncrementalDb, file: SourceFile) -> usize {
+    use std::sync::atomic::Ordering;
+    DEPS_PROBE_RUNS.fetch_add(1, Ordering::SeqCst);
+    project_declared_deps(db, file).map_or(0, |deps| deps.len())
+}
+
+static DEPS_PROBE_RUNS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// The other half of the firewall: an edit *within* the project file that
+/// leaves `[deps]` alone backdates, so a consumer of the declared set rests.
+#[test]
+fn a_compat_only_project_edit_backdates_declared_deps() {
+    use std::sync::atomic::Ordering;
+
+    let (mut db, _, project) =
+        project_db("[deps]\nFoo = \"11111111-2222-3333-4444-555555555555\"\n");
+
+    assert_eq!(probe_deps(&db, project), 1);
+    assert_eq!(DEPS_PROBE_RUNS.load(Ordering::SeqCst), 1);
+
+    db.set_file_text(
+        project,
+        "[deps]\nFoo = \"11111111-2222-3333-4444-555555555555\"\n\n[compat]\njulia = \"1.10\"\n",
+    );
+
+    // Witness: the file's text really changed, so the query re-ran.
+    assert!(db.file_text(project).contains("[compat]"));
+    assert_eq!(probe_deps(&db, project), 1);
+    assert_eq!(
+        DEPS_PROBE_RUNS.load(Ordering::SeqCst),
+        1,
+        "an edit that leaves `[deps]` alone must backdate rather than re-derive"
+    );
+}
+
+/// A project file that stops parsing takes the declared set with it, rather
+/// than reporting a half-typed `[deps]` table as the truth: `unresolved-import`
+/// goes quiet for a keystroke instead of flashing a false finding.
+#[test]
+fn a_broken_project_file_declares_nothing() {
+    let (db, _, _) = project_db("[deps]\nFoo = \n");
+    assert_eq!(db.declared_deps("MyPkg"), None);
+}
 
 /// A probe over the per-file host-module firewall, to observe backdating.
 #[salsa::tracked(returns(copy))]


### PR DESCRIPTION
**What and why**

`Project.toml` and `Manifest.toml` steer resolution but said nothing about
themselves. This branch gives them their own diagnostics and their own language
features, in the four stages `TODO.md` records under "Project files":

1. **Spans, then diagnostics** — `src/project_files.rs` holds seven checks
   (`toml-syntax` as an error; `missing-entry-file`, `missing-julia-compat`,
   `unknown-compat`, `missing-from-manifest`, `uuid-mismatch`, `missing-compat`
   as warnings), published on the file at fault whether or not it is open.
2. **Buffer for `[deps]`, disk for everything else** — a project file is now an
   ordinary salsa `SourceFile`, so editing `[deps]` updates
   `unresolved-import` across the package with no save.
3. **A real document** — `DocumentKind` (`Julia`/`Project`/`Manifest`), tagged
   once at `didOpen`, with a route of its own and live TOML diagnostics at edit
   cadence.
4. **Navigation** — an open `Project.toml` answers go-to-definition, hover,
   document links, and inlay hints on a dependency name; an open
   `Manifest.toml` links each `path` entry to the package it pins.

**Approach**

- **Not lint rules.** `Rule::interests()` is `SyntaxKind`-keyed over a single
  walk of the Julia CST, so a TOML check has no kind to register against.
  `project_files.rs` is also deliberately `lsp_types`-free — the mapping lives
  at the edge, so the CLI never has to grow a second copy (the mistake the
  include-graph analysis made).
- **The buffer supersedes the harvester, rather than joining it.** The two
  producers compute from different texts, so their union describes neither file.
- **`project.rs` stays range-free.** `tests/salsa_incremental.rs` guards both
  directions: a `Project.toml` edit reaches the declared deps and re-parses no
  Julia, and one that leaves `[deps]` alone backdates.
- **Three doors into the read pool, and only three**: `julia_text`,
  `project_text`, `manifest_text`. A hover or a format served off a TOML buffer
  would parse it as Julia, so everything Julia-backed answers `null` for these
  files.
- Only the project file gets a typed, `Spanned` schema; the manifest is typed
  for its `path` entries alone, against both of its layouts in turn, since
  `serde(flatten)`/`untagged` drop the span hook.

**Checklist**

- [x] Added or updated tests (test-first; a bug fix has a failing fixture that now passes)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt -- --check` is clean
- [x] Reviewed changed snapshots (`cargo insta review`), if any
- [x] Commits follow Conventional Commits
