### PR TITLE
chore(release): v0.15.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "aff9bd03b5073b0602e0118f50444e00e6d307e7",
+  "baseline-sha": "706e1d65e13e334ff3c40b9b876e10b5e5ed8c45",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.2",
-      "tag": "fatou-formatter-v0.3.2"
+      "version": "0.3.3",
+      "tag": "fatou-formatter-v0.3.3"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.4.0",
-      "tag": "fatou-parser-v0.4.0"
+      "version": "0.4.1",
+      "tag": "fatou-parser-v0.4.1"
     },
     {
       "path": "editors/code",
-      "version": "0.14.0",
-      "tag": "fatou-code-v0.14.0"
+      "version": "0.15.0",
+      "tag": "fatou-code-v0.15.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.2",
-      "tag": "fatou-formatter-v0.3.2"
+      "version": "0.3.3",
+      "tag": "fatou-formatter-v0.3.3"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.4.0",
-      "tag": "fatou-parser-v0.4.0"
+      "version": "0.4.1",
+      "tag": "fatou-parser-v0.4.1"
     },
     {
       "path": "editors/code",
-      "version": "0.14.0",
-      "tag": "fatou-code-v0.14.0"
+      "version": "0.15.0",
+      "tag": "fatou-code-v0.15.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/fatou/compare/v0.14.0...v0.15.0) (2026-08-16)
+
+### Features
+- **lsp:** send line-scoped formatting edits ([`6855e63`](https://github.com/jolars/fatou/commit/6855e63193a65c9c9ab1fb40ca7e2eae8c09c672))
+
+### Bug Fixes
+- **text:** restore `replace_range`'s panic contract ([`25dc59d`](https://github.com/jolars/fatou/commit/25dc59d97489350182506fb5baae83aae3db7027))
+
+### Performance Improvements
+- **text,lsp:** back document text with Arc<str> ([`6668392`](https://github.com/jolars/fatou/commit/6668392f133db4fb699dfd9219e7eb3e1ab46c93))
+- **check:** line-diff with Patience, not the default Myers ([`624f816`](https://github.com/jolars/fatou/commit/624f8168a251199b914bfcec5f55e26a24955578))
+- **lint:** render findings without rescanning the file each time ([`e3c8afc`](https://github.com/jolars/fatou/commit/e3c8afc5744326cd6499b7cbf446d00c64218e0e))
+
+### Dependencies
+- updated crates/fatou-formatter to v0.3.3
+- updated crates/fatou-parser to v0.4.1
+
 ## [0.14.0](https://github.com/jolars/fatou/compare/v0.13.0...v0.14.0) (2026-08-13)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "insta",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fluent-uri"
@@ -823,9 +823,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 readme = "README.md"
 description = "A language server, formatter, and linter for Julia"
@@ -49,8 +49,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.2" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.4.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.3" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.4.1" }
 globset = "0.4.18"
 ignore = "0.4.26"
 log = { version = "0.4.32", features = ["release_max_level_info"] }

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.3](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.2...fatou-formatter-v0.3.3) (2026-08-16)
+
+### Performance Improvements
+- **formatter:** stop copying the print stack per fit probe ([`9f317e3`](https://github.com/jolars/fatou/commit/9f317e32e84603fdb8538c7282078d940b93d3f4))
+
+### Dependencies
+- updated crates/fatou-parser to v0.4.1
+
 ## [0.3.2](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.1...fatou-formatter-v0.3.2) (2026-08-13)
 
 ### Dependencies

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 readme = "README.md"
 description = "Deterministic, rule-based formatter for the Julia language"
@@ -14,7 +14,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.4.0" }
+fatou-parser = { path = "../fatou-parser", version = "0.4.1" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.4.1](https://github.com/jolars/fatou/compare/fatou-parser-v0.4.0...fatou-parser-v0.4.1) (2026-08-16)
+
+### Bug Fixes
+- **parser:** cast the five wrapped kinds `Expr` dropped to `Other` ([`1347ed5`](https://github.com/jolars/fatou/commit/1347ed5b2e55410def89505fe1a07640eccde50f))
+
+### Performance Improvements
+- **parser:** borrow token text from the source ([`ac7f2e2`](https://github.com/jolars/fatou/commit/ac7f2e2a7ea6c68f7f24452c78d9b5df9780525c))
+- **parser:** fold docstrings in one linear pass ([`4f55e60`](https://github.com/jolars/fatou/commit/4f55e6028d9ccb4893b770ccf1b2f5419892748a))
+
 ## [0.4.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.3.0...fatou-parser-v0.4.0) (2026-08-13)
 
 ### Features

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 readme = "README.md"
 description = "Lossless CST parser, typed AST wrappers, and incremental reparser for the Julia language"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/fatou/compare/fatou-code-v0.14.0...fatou-code-v0.15.0) (2026-08-16)
+
+### Dependencies
+- updated fatou to v0.15.0
+
 ## [0.14.0](https://github.com/jolars/fatou/compare/fatou-code-v0.13.0...fatou-code-v0.14.0) (2026-08-13)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.14.0",
-    "@fatou-cli/linux-arm64-gnu": "0.14.0",
-    "@fatou-cli/linux-x64-musl": "0.14.0",
-    "@fatou-cli/linux-arm64-musl": "0.14.0",
-    "@fatou-cli/darwin-x64": "0.14.0",
-    "@fatou-cli/darwin-arm64": "0.14.0",
-    "@fatou-cli/win32-x64": "0.14.0",
-    "@fatou-cli/win32-arm64": "0.14.0"
+    "@fatou-cli/linux-x64-gnu": "0.15.0",
+    "@fatou-cli/linux-arm64-gnu": "0.15.0",
+    "@fatou-cli/linux-x64-musl": "0.15.0",
+    "@fatou-cli/linux-arm64-musl": "0.15.0",
+    "@fatou-cli/darwin-x64": "0.15.0",
+    "@fatou-cli/darwin-arm64": "0.15.0",
+    "@fatou-cli/win32-x64": "0.15.0",
+    "@fatou-cli/win32-arm64": "0.15.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.15.0](https://github.com/jolars/fatou/compare/v0.14.0...v0.15.0) (2026-08-16)

### Features
- **lsp:** send line-scoped formatting edits ([`6855e63`](https://github.com/jolars/fatou/commit/6855e63193a65c9c9ab1fb40ca7e2eae8c09c672))

### Bug Fixes
- **text:** restore `replace_range`'s panic contract ([`25dc59d`](https://github.com/jolars/fatou/commit/25dc59d97489350182506fb5baae83aae3db7027))

### Performance Improvements
- **text,lsp:** back document text with Arc<str> ([`6668392`](https://github.com/jolars/fatou/commit/6668392f133db4fb699dfd9219e7eb3e1ab46c93))
- **check:** line-diff with Patience, not the default Myers ([`624f816`](https://github.com/jolars/fatou/commit/624f8168a251199b914bfcec5f55e26a24955578))
- **lint:** render findings without rescanning the file each time ([`e3c8afc`](https://github.com/jolars/fatou/commit/e3c8afc5744326cd6499b7cbf446d00c64218e0e))

### Dependencies
- updated crates/fatou-formatter to v0.3.3
- updated crates/fatou-parser to v0.4.1

## [crates/fatou-formatter: 0.3.3](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.2...fatou-formatter-v0.3.3) (2026-08-16)

### Performance Improvements
- **formatter:** stop copying the print stack per fit probe ([`9f317e3`](https://github.com/jolars/fatou/commit/9f317e32e84603fdb8538c7282078d940b93d3f4))

### Dependencies
- updated crates/fatou-parser to v0.4.1

## [crates/fatou-parser: 0.4.1](https://github.com/jolars/fatou/compare/fatou-parser-v0.4.0...fatou-parser-v0.4.1) (2026-08-16)

### Bug Fixes
- **parser:** cast the five wrapped kinds `Expr` dropped to `Other` ([`1347ed5`](https://github.com/jolars/fatou/commit/1347ed5b2e55410def89505fe1a07640eccde50f))

### Performance Improvements
- **parser:** borrow token text from the source ([`ac7f2e2`](https://github.com/jolars/fatou/commit/ac7f2e2a7ea6c68f7f24452c78d9b5df9780525c))
- **parser:** fold docstrings in one linear pass ([`4f55e60`](https://github.com/jolars/fatou/commit/4f55e6028d9ccb4893b770ccf1b2f5419892748a))

## [editors/code: 0.15.0](https://github.com/jolars/fatou/compare/fatou-code-v0.14.0...fatou-code-v0.15.0) (2026-08-16)

### Dependencies
- updated fatou to v0.15.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).