### PR TITLE
perf(text): borrow token text and share document text as Arc<str>

### DIFF
--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -68,15 +68,18 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
   buffer, salsa's `SourceFile.text`, and the reparse base (`PrevParse.text`)
   hold the same allocation, so the write phase passes `text.text_arc()` (O(1))
   and the base stores a refcount bump. Reintroducing a `.text().to_string()`
-  on the dispatch path is the regression to watch for. Because the allocation
-  is shared, the staleness guards (`upsert_file`, `revert_file_to_disk`) put
+  on the dispatch path is the regression to watch for. Where the allocation can
+  be shared, the staleness guards (`upsert_file`, `parsed_document`) put
   `Arc::ptr_eq` **in front of** the content compare — never instead of it:
-  salsa's setter does no equality check at all, so the compare is what keeps a
-  no-op write from invalidating every memo. An edit rebuilds the string once
-  (`TextBuffer::replace_range`), which is the deliberate one linear pass a
-  keystroke pays for text; `benches/salsa_keystroke.rs` measures the whole
-  didChange → upsert → parse path, and is the bench that catches a cost added
-  *between* the pieces the other benches time.
+  salsa's setter does no equality check at all, so the *compare* is what keeps
+  a no-op write from invalidating every memo, and the `ptr_eq` only makes the
+  common case free. `revert_file_to_disk` has no such fast path and wants none:
+  its text comes off disk, so the allocations can never be shared. An edit
+  rebuilds the string once (`TextBuffer::replace_range`), which is the
+  deliberate linear pass a keystroke pays for text and the one place a
+  malformed range must still panic rather than splice. `benches/salsa_keystroke.rs`
+  measures the whole didChange → upsert → parse path, and is the bench that
+  catches a cost added *between* the pieces the other benches time.
 
 ## Conventions
 

--- a/.claude/rules/lsp.md
+++ b/.claude/rules/lsp.md
@@ -64,6 +64,19 @@ model. Capabilities are advertised by `server.rs::server_capabilities`,
   paths, where a full parse dwarfs the scan anyway. Reintroducing a rescan on
   the live-buffer path is a silent regression: it type-checks, because
   `&TextBuffer` derefs to `&str`. `benches/line_index.rs` is what measures it.
+- **The text itself is an `Arc<str>`, shared, never copied to hand over.** The
+  buffer, salsa's `SourceFile.text`, and the reparse base (`PrevParse.text`)
+  hold the same allocation, so the write phase passes `text.text_arc()` (O(1))
+  and the base stores a refcount bump. Reintroducing a `.text().to_string()`
+  on the dispatch path is the regression to watch for. Because the allocation
+  is shared, the staleness guards (`upsert_file`, `revert_file_to_disk`) put
+  `Arc::ptr_eq` **in front of** the content compare — never instead of it:
+  salsa's setter does no equality check at all, so the compare is what keeps a
+  no-op write from invalidating every memo. An edit rebuilds the string once
+  (`TextBuffer::replace_range`), which is the deliberate one linear pass a
+  keystroke pays for text; `benches/salsa_keystroke.rs` measures the whole
+  didChange → upsert → parse path, and is the bench that catches a cost added
+  *between* the pieces the other benches time.
 
 ## Conventions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ name = "line_index"
 harness = false
 
 [[bench]]
+name = "salsa_keystroke"
+harness = false
+
+[[bench]]
 name = "format_edits"
 harness = false
 

--- a/TODO.md
+++ b/TODO.md
@@ -155,30 +155,38 @@ juxtapose}.rs` out of `expr.rs` and added the kind-checked `events::finish`.
   `missing-entry-file`, so the mismatch is at least reported; the edit is
   *Project files* stage 4.
 
-- [ ] Maybe (deferred): a rope (`ropey`) for the live buffer, raised in #76.
-  It would make locating a line O(log n) and retire `LineStarts` outright. What
-  blocks it is narrower than #76's first reading, and it is *not* the lexer:
-  `Token` owns its `text: String` (`parser/lexer.rs`), so nothing borrows the
-  input and a chunk-based lexer is a local refactor. Nor the tree, formatter, or
-  linter — rowan's green tokens own their text and `SyntaxText` is already
-  chunked, and the warm LSP paths go through the CST (`format_node`,
-  `check_parsed`), never the source. The three real `&str` demands are
-  `parse(text: &str)`, `SourceFile.text: String` (`src/incremental.rs`), and
-  above all `reparse`/`reparse_edits`, whose token- and toplevel-tier guards
-  prove a splice sound by slicing and relexing regions of `prev_text`/
-  `new_text`. That last one is the wall: a rewrite of the most delicate code in
-  the parser crate.
-  Note also that the "a rope pays a `Rope::to_string` per keystroke" objection
-  is weaker than it looks — a keystroke already pays two full `String` copies
-  (`analysis_thread`'s `upsert_file`, and `PrevParse { text: text.clone() }`),
-  which a rope in salsa would replace with an O(1) CoW clone. The case for
-  deferring rests on the size of the prize instead: with the table patched per
-  edit (`src/text/buffer.rs`) a keystroke costs ~2% of the reparse it triggers,
-  so what is left to win is a memmove plus one add per line after the edit site,
-  against point queries the bench measured ~7x slower on a rope
-  (`benches/line_index.rs`). rust-analyzer keeps documents as a plain `String`
-  and applies edits with `replace_range` for the same reasons. Revisit only if
-  the reparse guards go chunk-based.
+- [x] The per-keystroke text copies are gone, and the rope from #76 stays
+  deferred — now on measurement rather than on argument. Two changes: `Token`
+  borrows its text from the input (`Token<'src> { text: &'src str }`), which
+  retired the per-token `String` and cut lexing ~65% and a full parse ~15%;
+  and the document text is one shared `Arc<str>` across the buffer, salsa's
+  `SourceFile`, and `PrevParse`, which turned the write-phase copy and the
+  base clone into refcount bumps and the staleness compare into `Arc::ptr_eq`
+  (a no-op upsert went 39 us -> 150 ns at 1 MB). An edit now rebuilds the
+  string instead of splicing in place, +10-30 us at 1 MB, well under the
+  reparse it precedes.
+
+  Measured against a full ropey conversion of the same paths (PR #85): the
+  rope reproduced none of the lexer win that the borrow alone gives — its
+  chunk machinery costs 10-19% against `&str` tokens, and its multi-chunk LSP
+  path another ~55% — and it cannot match `ptr_eq` on the unchanged-text
+  check, since rope equality walks chunks (27 us at 1 MB). What a rope
+  uniquely buys is the didChange splice: 0.7 us flat at 1 MB against our
+  ~34 us rebuild. That is real and nothing else reproduces it, but it is
+  ~30 us on a path whose reparse costs 150 us+, and the same branch lost
+  ~2.5 ms per keystroke to per-byte rope iteration in `diff_edit`. Revisit
+  only if fatou starts targeting documents where the splice dominates, and
+  only after the `diff_edit` bypass below.
+
+- [ ] Skip `diff_edit` when the staged chain is a single verified edit.
+  `parsed_document` declines a chain below two edits, so the ordinary
+  one-keystroke case always re-derives, by diffing the two whole texts, an
+  edit the language server just handed it. `benches/salsa_keystroke.rs` puts
+  that at ~200 us of a ~500 us keystroke at 1 MB — more than the token-tier
+  reparse it feeds. The chain is already verified against the previous text
+  (`reparse_edits`' fits check), so a single-edit chain can go straight to
+  `reparse` with no new trust; `diff_edit` stays the fallback for a text that
+  changed by a route carrying no edits.
 
 ## Project files (`Project.toml`/`Manifest.toml`)
 

--- a/benches/line_index.rs
+++ b/benches/line_index.rs
@@ -8,16 +8,16 @@
 //! edit (`src/text/buffer.rs`).
 //!
 //! This bench is the evidence for that shape, and the guard against a change
-//! that quietly reintroduces a rescan on the hot path. Measured on 2026-08-10
+//! that quietly reintroduces a rescan on the hot path. Measured on 2026-08-16
 //! (release, otherwise-idle machine — every row here scales with load, so read
 //! the ratios, not the absolutes):
 //!
 //! ```text
 //!                                   134 KB     1073 KB
-//! rescan (LineIndex::new)            26 us      316 us
+//! rescan (LineIndex::new)            14 us      117 us
 //! reuse the maintained table          1 ns        1 ns
-//! didChange (edit plus undo)        0.9 us      8.8 us
-//! reparse, token tier                33 us      257 us
+//! didChange (edit plus undo)        7.0 us       67 us
+//! reparse, token tier                19 us      154 us
 //! ```
 //!
 //! The `didChange` row applies a keystroke and then undoes it, so one
@@ -25,14 +25,20 @@
 //!
 //! A keystroke used to pay that rescan on the main loop before dispatching
 //! anything, and pay it again in every handler that answered against the
-//! buffer. It now costs about 2% of the reparse it triggers, and the handlers
-//! share the table rather than each rebuilding it.
+//! buffer. The handlers now share the table rather than each rebuilding it.
 //!
-//! Ropey was measured here too, and rejected (issue #76): fatou cannot keep the
-//! text as a rope, because `parse` takes `&str` and salsa's `SourceFile` input
-//! is a `String`, so every edit would have to flatten the rope — 90 us on
-//! 1 MB, an order of magnitude worse than patching a flat table, on top of
-//! point queries about 7x slower.
+//! The `didChange` row grew (it was 0.9/8.8 us against a `String` spliced in
+//! place) when the text became a shared `Arc<str>`: an edit rebuilds the
+//! string rather than mutating it, which is what makes every *handoff* of the
+//! text free. That trade is priced in `benches/salsa_keystroke.rs`, which
+//! times the whole keystroke rather than this one step — read the two
+//! together, and prefer the pipeline bench when judging a text-storage
+//! change.
+//!
+//! Ropey was measured against this design twice and deferred both times
+//! (issue #76, then PR #85): it wins this bench's didChange row outright
+//! (~0.7 us flat at 1 MB) and loses the point-query rows ~3-9x, but the
+//! pipeline bench is where that trade is actually settled. See `TODO.md`.
 //!
 //! Plain `main` (`harness = false`), same style as `format_compare`: no
 //! criterion dependency in the root crate, just a warm loop and a table.

--- a/benches/salsa_keystroke.rs
+++ b/benches/salsa_keystroke.rs
@@ -46,9 +46,12 @@ const UTF16: PositionEncoding = PositionEncoding::Utf16;
 
 /// The live buffer, as `upsert_file` takes it on this branch.
 ///
+/// Comparing branches means editing this body and the return type to match
+/// what that branch's `upsert_file` takes:
+///
 /// - `main`:               `live.text().to_string()` (an O(N) copy)
 /// - `experiment/arc-str`: `live.text_arc()` (a refcount bump)
-/// - `refactor/rope`:      `live.clone()` (an O(1) rope clone)
+/// - `refactor/rope`:      `live.rope().clone()` (an O(1) CoW rope clone)
 fn handoff(live: &TextBuffer) -> Arc<str> {
     live.text_arc()
 }

--- a/benches/salsa_keystroke.rs
+++ b/benches/salsa_keystroke.rs
@@ -1,0 +1,163 @@
+//! What one keystroke costs through the salsa pipeline, end to end.
+//!
+//! `benches/line_index.rs` times the pieces — the didChange splice, the
+//! position queries, the raw reparse — but nothing there walks the path a real
+//! keystroke takes: `apply_content_changes` on the live buffer, `upsert_file`
+//! handing the text to salsa, `reparse_stage_edits` staging the transform, and
+//! `parsed_document` consuming it. That path is where the per-keystroke text
+//! copies live (or don't), so it is the one row on which the text-storage
+//! designs — `String`, `Arc<str>`, a rope — are actually comparable.
+//!
+//! Three rows per size:
+//!
+//! 1. `upsert, text unchanged` — the staleness guard alone: what a no-op
+//!    upsert costs to prove there is nothing to do.
+//! 2. `splice + upsert + stage` — the write phase: the didChange splice plus
+//!    handing the changed text to salsa, no parse demanded.
+//! 3. `keystroke end-to-end` — the same plus `parsed_tree`, so the reparse the
+//!    keystroke triggers is included; row 3 minus row 2 cross-checks against
+//!    `line_index`'s token-tier row.
+//!
+//! Each timed iteration alternates inserting and deleting one character, so
+//! the text genuinely changes every round: salsa sees a fresh revision, the
+//! reparse base advances, and the printed number is one keystroke.
+//!
+//! The one line that differs per branch is [`handoff`], which converts the
+//! live buffer into what `upsert_file` takes on that branch.
+//!
+//! Plain `main` (`harness = false`), same style as `line_index`:
+//!
+//! ```sh
+//! bash bench/corpus/download.sh   # once
+//! cargo bench --bench salsa_keystroke
+//! ```
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use fatou::incremental::{IncrementalDatabase, IncrementalDb};
+use fatou::text::{PositionEncoding, TextBuffer, apply_content_changes};
+use lsp_types::{Position, Range, TextDocumentContentChangeEvent};
+
+const UTF16: PositionEncoding = PositionEncoding::Utf16;
+
+/// The live buffer, as `upsert_file` takes it on this branch.
+///
+/// - `main`:               `live.text().to_string()` (an O(N) copy)
+/// - `experiment/arc-str`: `live.text_arc()` (a refcount bump)
+/// - `refactor/rope`:      `live.clone()` (an O(1) rope clone)
+fn handoff(live: &TextBuffer) -> Arc<str> {
+    live.text_arc()
+}
+
+fn corpus() -> Option<String> {
+    let dir: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("bench/corpus/JuliaSyntax/src");
+    fs::read_to_string(dir.join("parser.jl")).ok()
+}
+
+/// Time `f` in a warm loop, returning nanoseconds per iteration.
+fn time<T>(iters: usize, mut f: impl FnMut() -> T) -> f64 {
+    for _ in 0..(iters / 10).max(1) {
+        black_box(f());
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        black_box(f());
+    }
+    start.elapsed().as_nanos() as f64 / iters as f64
+}
+
+fn row(name: &str, ns: f64) {
+    let time = if ns < 1_000.0 {
+        format!("{ns:>8.0} ns")
+    } else if ns < 1_000_000.0 {
+        format!("{:>8.2} us", ns / 1_000.0)
+    } else {
+        format!("{:>8.3} ms", ns / 1_000_000.0)
+    };
+    println!("{name:<40}{time}");
+}
+
+fn bench_size(label: &str, text: &str, iters: [usize; 3]) {
+    println!("\n=== {label} ({} KB) ===", text.len() / 1024);
+
+    // The edit site: ~80% of the way through the buffer, on a char boundary.
+    let mut at = text.len() * 4 / 5;
+    while !text.is_char_boundary(at) {
+        at += 1;
+    }
+    let mut live = TextBuffer::from(text);
+    let position = live.line_index().byte_to_position(at, UTF16);
+    let insert = vec![TextDocumentContentChangeEvent {
+        range: Some(Range::new(position, position)),
+        range_length: None,
+        text: "z".to_string(),
+    }];
+    let after_z = Position::new(position.line, position.character + 1);
+    let delete = vec![TextDocumentContentChangeEvent {
+        range: Some(Range::new(position, after_z)),
+        range_length: None,
+        text: String::new(),
+    }];
+
+    let mut db = IncrementalDatabase::new();
+    let path = PathBuf::from("/bench/keystroke.jl");
+    let file = db.upsert_file(&path, handoff(&live));
+    black_box(db.parsed_tree(file));
+
+    row(
+        "upsert, text unchanged",
+        time(iters[0], || {
+            black_box(db.upsert_file(&path, handoff(&live)))
+        }),
+    );
+
+    // Alternate an insert and a delete so every iteration is a genuine text
+    // change: a fresh salsa revision, never a memoized no-op.
+    let mut flip = false;
+    row(
+        "splice + upsert + stage (write phase)",
+        time(iters[1], || {
+            flip = !flip;
+            let batch = if flip { insert.clone() } else { delete.clone() };
+            let edits = apply_content_changes(&mut live, batch, UTF16);
+            let file = db.upsert_file(&path, handoff(&live));
+            db.reparse_stage_edits(file, edits);
+            file
+        }),
+    );
+
+    // Row 2 left a long staged chain with no parse consuming it; drop it and
+    // resync the base so row 3 starts from a clean, current parse.
+    db.reparse_stage_edits(file, None);
+    black_box(db.parsed_tree(file));
+
+    let mut flip = false;
+    row(
+        "keystroke end-to-end (parse included)",
+        time(iters[2], || {
+            flip = !flip;
+            let batch = if flip { insert.clone() } else { delete.clone() };
+            let edits = apply_content_changes(&mut live, batch, UTF16);
+            let file = db.upsert_file(&path, handoff(&live));
+            db.reparse_stage_edits(file, edits);
+            black_box(db.parsed_tree(file))
+        }),
+    );
+}
+
+fn main() {
+    let Some(src) = corpus() else {
+        eprintln!("corpus missing; run `bash bench/corpus/download.sh` first");
+        return;
+    };
+    bench_size("JuliaSyntax/src/parser.jl", &src, [10_000, 2_000, 500]);
+
+    // The same file over and over: not a plausible source file, but it shows
+    // how each row scales with buffer size, which is the whole question.
+    let big: String = std::iter::repeat_n(src.as_str(), 8).collect();
+    bench_size("the same file x8", &big, [2_000, 500, 200]);
+}

--- a/crates/fatou-parser/src/parser/context.rs
+++ b/crates/fatou-parser/src/parser/context.rs
@@ -22,7 +22,7 @@ const PARSER_STEP_LIMIT: u32 = 15_000_000;
 /// A lightweight wrapper over the token slice with cursor helpers, threaded
 /// through the parser so navigation reads the same way everywhere.
 pub(crate) struct ParserCtx<'a> {
-    tokens: &'a [Token],
+    tokens: &'a [Token<'a>],
     /// Consecutive peeks since the last frontier advance (the stuck-loop guard).
     steps: Cell<u32>,
     /// The furthest token index any peek has reached; forward progress resets
@@ -31,7 +31,7 @@ pub(crate) struct ParserCtx<'a> {
 }
 
 impl<'a> ParserCtx<'a> {
-    pub(crate) fn new(tokens: &'a [Token]) -> Self {
+    pub(crate) fn new(tokens: &'a [Token<'a>]) -> Self {
         Self {
             tokens,
             steps: Cell::new(0),
@@ -61,12 +61,12 @@ impl<'a> ParserCtx<'a> {
         self.steps.set(steps + 1);
     }
 
-    pub(crate) fn token(&self, i: usize) -> Option<&'a Token> {
+    pub(crate) fn token(&self, i: usize) -> Option<&'a Token<'a>> {
         self.step(i);
         self.tokens.get(i)
     }
 
-    pub(crate) fn tokens(&self) -> &'a [Token] {
+    pub(crate) fn tokens(&self) -> &'a [Token<'a>] {
         self.tokens
     }
 

--- a/crates/fatou-parser/src/parser/expr.rs
+++ b/crates/fatou-parser/src/parser/expr.rs
@@ -1009,7 +1009,7 @@ fn is_typegroup_keyword(ctx: &ParserCtx<'_>, start: usize) -> bool {
     match ctx.token(next) {
         Some(t) => match t.kind {
             TokKind::StructKw | TokKind::MutableKw | TokKind::At | TokKind::StringDelimOpen => true,
-            TokKind::Ident => matches!(t.text.as_ref(), "abstract" | "primitive"),
+            TokKind::Ident => matches!(t.text, "abstract" | "primitive"),
             _ => false,
         },
         None => false,
@@ -1462,7 +1462,7 @@ fn parse_prefix(
         // prefix-only Unicode radicals `√ ∛ ∜ ¬` (`√x` → `(call-pre √ x)`, with
         // the same precedence as `-`/`+`), and the unary-capable Unicode
         // arithmetic operators `± ∓ ⋆` (`±x` → `(call-pre ± x)`).
-        k if is_unary_prefix_op(k, &tok.text) => {
+        k if is_unary_prefix_op(k, tok.text) => {
             // A unary arithmetic/logical operator glued to a `(` is a call when
             // the parens look like an argument list (`+(x, y)` → `(call + x y)`,
             // `+(a...)` → `(call + (... a))`, `+(a; b, c)` → `(call + a
@@ -1718,7 +1718,7 @@ fn parse_prefix(
         // (`'` ⇒ `(char (error))`, `'a` ⇒ `(char 'a' (error-t))`).
         TokKind::Char => {
             let tok = &ctx.tokens()[start];
-            if !char_token_terminated(&tok.text) {
+            if !char_token_terminated(tok.text) {
                 push_diagnostic(
                     diagnostics,
                     DiagnosticKind::UnterminatedLiteral,
@@ -2232,7 +2232,7 @@ pub(super) fn parse_quote_sym(
         // fall through to the bare-operator arm below (`:..` ⇒ `(quote-: ..)`).
         _ if ctx
             .token(next)
-            .is_some_and(|t| is_dotted_broadcast_text(&t.text)) =>
+            .is_some_and(|t| is_dotted_broadcast_text(t.text)) =>
         {
             events.push(Event::Start(SyntaxKind::OPERATOR_ATOM));
             events.push(Event::Tok(next));
@@ -2295,7 +2295,7 @@ fn parse_string_literal(
     let mut has_prefix = false;
     if ctx.token(i).map(|t| t.kind) == Some(TokKind::StringPrefix) {
         has_prefix = true;
-        var_prefix = ctx.token(i).map(|t| t.text.as_str()) == Some("var");
+        var_prefix = ctx.token(i).map(|t| t.text) == Some("var");
         i += 1;
     }
 

--- a/crates/fatou-parser/src/parser/lexer.rs
+++ b/crates/fatou-parser/src/parser/lexer.rs
@@ -55,15 +55,17 @@ impl TokKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Token {
+pub(crate) struct Token<'src> {
     pub(crate) kind: TokKind,
-    pub(crate) text: String,
+    pub(crate) text: &'src str,
     pub(crate) start: usize,
     pub(crate) end: usize,
 }
 
-/// Tokenize `input` into a lossless token stream.
-pub(crate) fn lex(input: &str) -> Vec<Token> {
+/// Tokenize `input` into a lossless token stream. Tokens borrow their text
+/// from `input`: the text is always a verbatim slice, so no token needs an
+/// allocation of its own.
+pub(crate) fn lex(input: &str) -> Vec<Token<'_>> {
     Lexer::new(input).run()
 }
 
@@ -95,7 +97,7 @@ struct Lexer<'a> {
     input: &'a str,
     bytes: &'a [u8],
     pos: usize,
-    tokens: Vec<Token>,
+    tokens: Vec<Token<'a>>,
     mode_stack: Vec<Mode>,
 }
 
@@ -110,7 +112,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn run(mut self) -> Vec<Token> {
+    fn run(mut self) -> Vec<Token<'a>> {
         while self.pos < self.bytes.len() {
             self.next_token();
         }
@@ -124,7 +126,7 @@ impl<'a> Lexer<'a> {
     fn push(&mut self, kind: TokKind, start: usize, end: usize) {
         self.tokens.push(Token {
             kind,
-            text: self.input[start..end].to_string(),
+            text: &self.input[start..end],
             start,
             end,
         });

--- a/crates/fatou-parser/src/parser/reparse.rs
+++ b/crates/fatou-parser/src/parser/reparse.rs
@@ -1165,9 +1165,10 @@ mod tests {
     /// the test fails loudly rather than quietly covering nothing.
     #[test]
     fn every_contextual_ident_is_listed() {
-        // `t.kind == TokKind::Ident && t.text == "word"` and the `matches!`
-        // form `matches!(t.text, "word" | "other")`. Both are keyed on
-        // `t.text`, which is what makes them text-structural.
+        // `t.kind == TokKind::Ident && t.text == "word"` and any form that
+        // passes `t.text` along to a comparison, `matches!(t.text, "word" |
+        // "other")` above all. Both are keyed on `t.text`, which is what makes
+        // them text-structural.
         fn words_after(haystack: &str, marker: &str) -> Vec<String> {
             let mut out = Vec::new();
             for tail in haystack.split(marker).skip(1) {
@@ -1194,7 +1195,7 @@ mod tests {
             let src = std::fs::read_to_string(dir.join(name))
                 .unwrap_or_else(|e| panic!("read {name}: {e}"));
             found.extend(words_after(&src, "t.text =="));
-            found.extend(words_after(&src, "matches!(t.text,"));
+            found.extend(words_after(&src, "t.text,"));
             found.extend(words_after(&src, "next.text =="));
         }
         assert!(

--- a/crates/fatou-parser/src/parser/reparse.rs
+++ b/crates/fatou-parser/src/parser/reparse.rs
@@ -1166,7 +1166,7 @@ mod tests {
     #[test]
     fn every_contextual_ident_is_listed() {
         // `t.kind == TokKind::Ident && t.text == "word"` and the `matches!`
-        // form `matches!(t.text.as_ref(), "word" | "other")`. Both are keyed on
+        // form `matches!(t.text, "word" | "other")`. Both are keyed on
         // `t.text`, which is what makes them text-structural.
         fn words_after(haystack: &str, marker: &str) -> Vec<String> {
             let mut out = Vec::new();
@@ -1194,7 +1194,7 @@ mod tests {
             let src = std::fs::read_to_string(dir.join(name))
                 .unwrap_or_else(|e| panic!("read {name}: {e}"));
             found.extend(words_after(&src, "t.text =="));
-            found.extend(words_after(&src, "t.text.as_ref(),"));
+            found.extend(words_after(&src, "matches!(t.text,"));
             found.extend(words_after(&src, "next.text =="));
         }
         assert!(

--- a/crates/fatou-parser/src/parser/tree_builder.rs
+++ b/crates/fatou-parser/src/parser/tree_builder.rs
@@ -27,7 +27,7 @@ pub(crate) fn build_tree(tokens: &[Token], events: &[Event]) -> SyntaxNode {
 }
 
 fn push_token(builder: &mut GreenNodeBuilder<'_>, tok: &Token) {
-    builder.token(syntax_kind_for(tok.kind).into(), tok.text.as_str());
+    builder.token(syntax_kind_for(tok.kind).into(), tok.text);
 }
 
 /// Debug-only guard that the event stream opens and closes in balance: every

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -236,7 +236,10 @@ pub fn parsed_document(db: &dyn IncrementalDb, file: SourceFile) -> ParsedDocume
     // a write that set the text back to what the base holds. Nothing is stored:
     // the base has not moved, and the staged chain stays anchored to it (its
     // net effect is a no-op, so a later edit appended to it still describes the
-    // transform from the base).
+    // transform from the base). The `ptr_eq` is the free half of the check —
+    // the base normally holds the very allocation salsa tracks — and the
+    // compare behind it is what makes the guard correct for a base rebuilt
+    // from equal-but-distinct text.
     if let Some(prev) = prev
         .as_ref()
         .filter(|prev| Arc::ptr_eq(&prev.text, text) || prev.text == *text)
@@ -1030,9 +1033,14 @@ impl IncrementalDatabase {
         let existing = self.source_map().by_path.get(&key).copied();
         match existing {
             Some(file) => {
-                // Salsa's setter never compares, so this guard is what stops a
-                // no-op upsert from invalidating the world. A shared allocation
-                // proves equality without reading a byte.
+                // Salsa's setter never compares, so this guard — the compare,
+                // not the `ptr_eq` — is what stops a no-op upsert from
+                // invalidating the world. The `ptr_eq` in front only makes the
+                // common case free: a shared allocation proves equality
+                // without reading a byte. It is written out rather than left to
+                // `Arc`'s own `PartialEq`, whose identical short-circuit is an
+                // unspecified `std` optimization, and this is a path whose cost
+                // the benches pin.
                 let tracked = file.text(self);
                 if !Arc::ptr_eq(tracked, &text) && *tracked != text {
                     file.set_text(self).to(text);

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -48,8 +48,11 @@ pub struct SourceFile {
     /// document. Set once at creation and never mutated.
     #[returns(ref)]
     pub path: Option<PathBuf>,
+    /// The document text as a shared immutable handle: setting it moves an
+    /// `Arc` in, and [`PrevParse`] and the live buffer share the same
+    /// allocation, so text changes hands without being copied.
     #[returns(ref)]
-    pub text: String,
+    pub text: Arc<str>,
 }
 
 /// The harvested library index: every resolved package's [`PackageIndex`]
@@ -152,7 +155,7 @@ pub struct ParsedDocument {
 /// tracked query sound.
 #[derive(Debug, Clone)]
 pub struct PrevParse {
-    pub text: String,
+    pub text: Arc<str>,
     pub green: rowan::GreenNode,
     pub diagnostics: Vec<ParseDiagnostic>,
 }
@@ -234,7 +237,10 @@ pub fn parsed_document(db: &dyn IncrementalDb, file: SourceFile) -> ParsedDocume
     // the base has not moved, and the staged chain stays anchored to it (its
     // net effect is a no-op, so a later edit appended to it still describes the
     // transform from the base).
-    if let Some(prev) = prev.as_ref().filter(|prev| prev.text == *text) {
+    if let Some(prev) = prev
+        .as_ref()
+        .filter(|prev| Arc::ptr_eq(&prev.text, text) || prev.text == *text)
+    {
         return ParsedDocument {
             green: prev.green.clone(),
             diagnostics: prev.diagnostics.clone(),
@@ -252,7 +258,7 @@ pub fn parsed_document(db: &dyn IncrementalDb, file: SourceFile) -> ParsedDocume
     let (green, diagnostics) = match reparsed {
         Some(r) => (r.green, r.diagnostics),
         None => {
-            let parsed = parse(text.as_str());
+            let parsed = parse(text);
             (parsed.cst.green().to_owned(), parsed.diagnostics)
         }
     };
@@ -1011,19 +1017,24 @@ impl IncrementalDatabase {
 
     /// Track an in-memory document with no on-disk path. Gets a fresh
     /// [`FileId`] and a `None` path, so it never aliases another file.
-    pub fn add_file(&self, text: impl Into<String>) -> SourceFile {
+    pub fn add_file(&self, text: impl Into<Arc<str>>) -> SourceFile {
         let id = self.source_map().alloc_id();
         SourceFile::new(self, id, None, text.into())
     }
 
     /// Track (or reuse) the file at `path`, replacing its text. Equivalent path
     /// spellings map to the same input.
-    pub fn upsert_file(&mut self, path: &Path, text: String) -> SourceFile {
+    pub fn upsert_file(&mut self, path: &Path, text: impl Into<Arc<str>>) -> SourceFile {
         let key = normalize_path(path);
+        let text = text.into();
         let existing = self.source_map().by_path.get(&key).copied();
         match existing {
             Some(file) => {
-                if file.text(self) != &text {
+                // Salsa's setter never compares, so this guard is what stops a
+                // no-op upsert from invalidating the world. A shared allocation
+                // proves equality without reading a byte.
+                let tracked = file.text(self);
+                if !Arc::ptr_eq(tracked, &text) && *tracked != text {
                     file.set_text(self).to(text);
                 }
                 file
@@ -1043,13 +1054,13 @@ impl IncrementalDatabase {
         self.source_map().by_path.get(&key).copied()
     }
 
-    pub fn set_file_text(&mut self, file: SourceFile, text: impl Into<String>) {
+    pub fn set_file_text(&mut self, file: SourceFile, text: impl Into<Arc<str>>) {
         file.set_text(self).to(text.into());
     }
 
     /// The text currently tracked for `file`.
     pub fn file_text(&self, file: SourceFile) -> &str {
-        file.text(self).as_str()
+        file.text(self)
     }
 
     /// The on-disk path `file` was tracked under, or `None` for an in-memory
@@ -1243,7 +1254,7 @@ impl IncrementalDatabase {
         }
         let text = std::fs::read_to_string(&key).ok()?;
         let id = self.source_map().alloc_id();
-        let file = SourceFile::new(self, id, Some(key.clone()), text);
+        let file = SourceFile::new(self, id, Some(key.clone()), Arc::from(text));
         self.source_map().by_path.insert(key, file);
         Some(file)
     }
@@ -1282,8 +1293,8 @@ impl IncrementalDatabase {
         let Ok(text) = std::fs::read_to_string(path) else {
             return;
         };
-        if file.text(self) != &text {
-            file.set_text(self).to(text);
+        if **file.text(self) != *text {
+            file.set_text(self).to(Arc::from(text));
         }
     }
 
@@ -1600,8 +1611,8 @@ mod tests {
     #[test]
     fn upsert_dedups_by_normalized_path() {
         let mut db = IncrementalDatabase::new();
-        let a = db.upsert_file(Path::new("/tmp/a.jl"), "x = 1\n".into());
-        let b = db.upsert_file(Path::new("/tmp/./a.jl"), "x = 2\n".into());
+        let a = db.upsert_file(Path::new("/tmp/a.jl"), "x = 1\n");
+        let b = db.upsert_file(Path::new("/tmp/./a.jl"), "x = 2\n");
         assert!(a == b, "equivalent path spellings should reuse one input");
         assert_eq!(parsed_tree_root(&db, a).to_string(), "x = 2\n");
     }
@@ -1620,7 +1631,7 @@ mod tests {
         assert!(db.source_map.is_poisoned(), "the mutex should be poisoned");
 
         // Every path through the recovery helper still works.
-        let file = db.upsert_file(Path::new("/tmp/x.jl"), "x = 1\n".into());
+        let file = db.upsert_file(Path::new("/tmp/x.jl"), "x = 1\n");
         assert!(
             db.lookup_file(Path::new("/tmp/x.jl")) == Some(file),
             "lookup should find the just-upserted file after poison recovery"

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -480,7 +480,7 @@ impl AnalysisWorker {
     fn start(&mut self, mut req: AnalysisRequest) {
         // Write-phase: push the live buffer into the persistent db. Cheap —
         // the parse is a lazy salsa query deferred to the read-phase.
-        let file = self.db.upsert_file(&req.path, req.text.text().to_string());
+        let file = self.db.upsert_file(&req.path, req.text.text_arc());
         // Hand the precise edits to the incremental reparse. Staged after the
         // text so the chain is never ahead of the buffer it describes, and
         // appended rather than replaced so a chain the previous read never got

--- a/src/lsp/analysis_thread.rs
+++ b/src/lsp/analysis_thread.rs
@@ -800,6 +800,49 @@ mod tests {
         assert_eq!(done, 2, "both analyses should have signaled done");
     }
 
+    /// The write phase hands salsa the live buffer's own allocation, never a
+    /// copy of it. A `req.text.text().to_string()` here would still type-check
+    /// and still be correct — it would just copy the whole document on every
+    /// keystroke, which is the one regression no other test or bench notices
+    /// (`.claude/rules/lsp.md`, `benches/salsa_keystroke.rs`).
+    #[test]
+    fn the_write_phase_shares_the_buffers_allocation() {
+        use crate::lsp::lint::ServerRules;
+        use crate::lsp::task_pool::TaskPool;
+
+        // A live pool and live receivers: `start` spawns its read-phase, and a
+        // dead channel would fail the send on the pool thread.
+        let pool = TaskPool::new("test-analysis-share", 1);
+        let (out_tx, _out_rx) = crossbeam_channel::unbounded::<Outbound>();
+        let (done_tx, _done_rx) = crossbeam_channel::unbounded::<AnalyzeDone>();
+        let mut worker = AnalysisWorker {
+            read_spawner: pool.spawner(),
+            out_tx,
+            done_tx,
+            ..AnalysisWorker::for_test()
+        };
+
+        let text = Arc::new(TextBuffer::from("x = 1\n"));
+        let path = PathBuf::from("/work/share.jl");
+        worker.start(AnalysisRequest {
+            uri: uri_named("share.jl"),
+            path: path.clone(),
+            text: Arc::clone(&text),
+            version: 1,
+            rules: ServerRules::defaults(),
+            edits: None,
+        });
+
+        let file = worker
+            .db
+            .lookup_file(&path)
+            .expect("the write phase tracks the file it upserts");
+        assert!(
+            Arc::ptr_eq(&text.text_arc(), file.text(&worker.db)),
+            "the write phase must hand salsa the buffer's allocation, not a copy"
+        );
+    }
+
     /// Coalescing drops the superseded request wholesale, so its edits have to
     /// ride along on the survivor: what reaches the db must describe the
     /// transform from the last *analyzed* text, not from the last enqueued one.

--- a/src/text/buffer.rs
+++ b/src/text/buffer.rs
@@ -33,7 +33,10 @@ pub struct TextBuffer {
 /// Two buffers are equal when their text is. Deriving this would also walk the
 /// line tables, which the type's whole invariant says are a function of the
 /// text — so that comparison could only ever agree, at a cost linear in the
-/// number of lines. Shared allocations are equal without reading a byte.
+/// number of lines. Shared allocations are equal without reading a byte: the
+/// `ptr_eq` is written out because that is a property this design relies on,
+/// not one to inherit from `Arc`'s own `PartialEq`, whose identical
+/// short-circuit is an unspecified `std` optimization.
 impl PartialEq for TextBuffer {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.text, &other.text) || self.text == other.text
@@ -101,6 +104,11 @@ impl TextBuffer {
 
     /// Replace the whole buffer, rescanning. This is the `didChange`-without-a-
     /// range case and the `didOpen` case; there is no edit to patch with.
+    ///
+    /// A `String` caller pays a copy here that it did not when the buffer owned
+    /// one, since `Arc<str>` cannot adopt a `String`'s allocation. Accepted:
+    /// both callers already rescan the whole text on the same line, and neither
+    /// is on the keystroke path.
     pub fn set_text(&mut self, text: impl Into<Arc<str>>) {
         self.text = text.into();
         self.line_starts = LineStarts::new(&self.text);

--- a/src/text/buffer.rs
+++ b/src/text/buffer.rs
@@ -72,15 +72,26 @@ impl TextBuffer {
 
     /// Replace the bytes in `range` with `insert`, patching the line table
     /// rather than rebuilding it. The immutable text is rebuilt around the
-    /// splice — the deliberate one-linear-pass-per-edit that buys the O(1)
-    /// sharing everywhere else.
+    /// splice — the deliberate linear pass per edit that buys the O(1) sharing
+    /// everywhere else. It costs two copies of the buffer, not one, because
+    /// `Arc<str>` cannot adopt the `String`'s allocation; halving that means
+    /// storing `Arc<String>` and splicing through `Arc::make_mut`, which is
+    /// only worth it if this row ever stops being dwarfed by the reparse
+    /// (`benches/salsa_keystroke.rs`).
     ///
-    /// Panics on a range that is out of bounds or not on a char boundary, as
-    /// [`String::replace_range`] does.
+    /// Panics on a reversed range, one that is out of bounds, or one off a char
+    /// boundary, as [`String::replace_range`] does.
     pub fn replace_range(&mut self, range: Range<usize>, insert: &str) {
+        // Slice the removed region up front, which is what reproduces
+        // `String::replace_range`'s panics *and* what keeps a bad range from
+        // leaving a patched table over unpatched text. The length arithmetic
+        // below cannot stand in for it: a reversed range has length zero, so
+        // the splice would silently duplicate `end..start`, and an
+        // out-of-bounds one underflows into a bogus capacity.
+        let removed = self.text[range.clone()].len();
         self.line_starts.patch(range.clone(), insert);
         let old = &self.text;
-        let mut new = String::with_capacity(old.len() - range.len() + insert.len());
+        let mut new = String::with_capacity(old.len() - removed + insert.len());
         new.push_str(&old[..range.start]);
         new.push_str(insert);
         new.push_str(&old[range.end..]);
@@ -203,5 +214,32 @@ mod tests {
         );
         assert_eq!(&*before, "ab\ncd");
         assert_eq!(buffer.text(), "ab\nxy\ncd");
+    }
+
+    /// A malformed range must panic where [`String::replace_range`] would.
+    /// Rebuilding the text around the splice can no longer rely on the string
+    /// machinery to reject one, and the arithmetic that replaced it accepts
+    /// both of the shapes below: a reversed range measures zero and would
+    /// duplicate the region it names, an out-of-bounds one underflows.
+    #[test]
+    #[should_panic(expected = "byte range starts at 4 but ends at 2")]
+    #[expect(
+        clippy::reversed_empty_ranges,
+        reason = "the malformed range is the subject of the test"
+    )]
+    fn a_reversed_edit_range_panics() {
+        TextBuffer::from("abcdefgh").replace_range(4..2, "Z");
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn an_out_of_bounds_edit_range_panics() {
+        TextBuffer::from("abcdefgh").replace_range(0..99, "Z");
+    }
+
+    #[test]
+    #[should_panic(expected = "not a char boundary")]
+    fn an_edit_range_off_a_char_boundary_panics() {
+        TextBuffer::from("\u{1F600}x").replace_range(1..2, "Z");
     }
 }

--- a/src/text/buffer.rs
+++ b/src/text/buffer.rs
@@ -12,38 +12,50 @@
 //! after the edit site, and every reader shares the result.
 
 use std::ops::{Deref, Range};
+use std::sync::Arc;
 
 use super::line_index::{LineIndex, LineStarts};
 
 /// Text plus the line-start table that indexes it, kept in step.
 ///
+/// The text is an immutable `Arc<str>`, so handing it to the salsa layer or a
+/// read job is a refcount bump, never a copy; an edit rebuilds the string once
+/// and that rebuild is the one linear cost a keystroke pays for text.
+///
 /// Derefs to `str`, so anything that just wants the text — `parse`, the
 /// formatter, the linter — takes it unchanged.
 #[derive(Debug, Clone, Default, Eq)]
 pub struct TextBuffer {
-    text: String,
+    text: Arc<str>,
     line_starts: LineStarts,
 }
 
 /// Two buffers are equal when their text is. Deriving this would also walk the
 /// line tables, which the type's whole invariant says are a function of the
 /// text — so that comparison could only ever agree, at a cost linear in the
-/// number of lines.
+/// number of lines. Shared allocations are equal without reading a byte.
 impl PartialEq for TextBuffer {
     fn eq(&self, other: &Self) -> bool {
-        self.text == other.text
+        Arc::ptr_eq(&self.text, &other.text) || self.text == other.text
     }
 }
 
 impl TextBuffer {
     /// Take ownership of `text`, scanning it once for its line starts.
-    pub fn new(text: String) -> Self {
+    pub fn new(text: impl Into<Arc<str>>) -> Self {
+        let text = text.into();
         let line_starts = LineStarts::new(&text);
         Self { text, line_starts }
     }
 
     pub fn text(&self) -> &str {
         &self.text
+    }
+
+    /// The text as a shared handle: an O(1) clone, for the salsa boundary and
+    /// anything else that stores the document rather than borrowing it.
+    pub fn text_arc(&self) -> Arc<str> {
+        Arc::clone(&self.text)
     }
 
     /// The maintained table, for a caller building its own [`LineIndex`].
@@ -59,25 +71,32 @@ impl TextBuffer {
     }
 
     /// Replace the bytes in `range` with `insert`, patching the line table
-    /// rather than rebuilding it.
+    /// rather than rebuilding it. The immutable text is rebuilt around the
+    /// splice — the deliberate one-linear-pass-per-edit that buys the O(1)
+    /// sharing everywhere else.
     ///
     /// Panics on a range that is out of bounds or not on a char boundary, as
     /// [`String::replace_range`] does.
     pub fn replace_range(&mut self, range: Range<usize>, insert: &str) {
         self.line_starts.patch(range.clone(), insert);
-        self.text.replace_range(range, insert);
+        let old = &self.text;
+        let mut new = String::with_capacity(old.len() - range.len() + insert.len());
+        new.push_str(&old[..range.start]);
+        new.push_str(insert);
+        new.push_str(&old[range.end..]);
+        self.text = Arc::from(new);
         self.debug_assert_in_step();
     }
 
     /// Replace the whole buffer, rescanning. This is the `didChange`-without-a-
     /// range case and the `didOpen` case; there is no edit to patch with.
-    pub fn set_text(&mut self, text: String) {
-        self.text = text;
+    pub fn set_text(&mut self, text: impl Into<Arc<str>>) {
+        self.text = text.into();
         self.line_starts = LineStarts::new(&self.text);
     }
 
     pub fn into_string(self) -> String {
-        self.text
+        self.text.to_string()
     }
 
     /// The invariant the type exists to uphold: the table is always exactly
@@ -105,13 +124,13 @@ impl Deref for TextBuffer {
 /// of it, and [`TextBuffer`] is the thing keeping that true.
 impl PartialEq<str> for TextBuffer {
     fn eq(&self, other: &str) -> bool {
-        self.text == other
+        &*self.text == other
     }
 }
 
 impl PartialEq<TextBuffer> for str {
     fn eq(&self, other: &TextBuffer) -> bool {
-        self == other.text.as_str()
+        self == &*other.text
     }
 }
 
@@ -123,7 +142,13 @@ impl From<String> for TextBuffer {
 
 impl From<&str> for TextBuffer {
     fn from(text: &str) -> Self {
-        Self::new(text.to_string())
+        Self::new(text)
+    }
+}
+
+impl From<Arc<str>> for TextBuffer {
+    fn from(text: Arc<str>) -> Self {
+        Self::new(text)
     }
 }
 

--- a/src/text/buffer.rs
+++ b/src/text/buffer.rs
@@ -183,4 +183,25 @@ mod tests {
         assert_eq!(buffer.line_index().line_count(), 2);
         assert_eq!(buffer.line_starts(), &LineStarts::new(&buffer));
     }
+
+    /// The whole point of the `Arc<str>` representation: handing the text out
+    /// shares one allocation, and an edit replaces the allocation without
+    /// disturbing handles taken before it — which is what lets the salsa
+    /// layer, the reparse base, and in-flight read jobs hold the text without
+    /// copying it.
+    #[test]
+    fn text_arc_shares_until_an_edit_and_then_snapshots() {
+        let mut buffer = TextBuffer::from("ab\ncd");
+        let before = buffer.text_arc();
+        assert!(Arc::ptr_eq(&before, &buffer.text_arc()));
+        assert!(Arc::ptr_eq(&before, &buffer.clone().text_arc()));
+
+        buffer.replace_range(2..2, "\nxy");
+        assert!(
+            !Arc::ptr_eq(&before, &buffer.text_arc()),
+            "an edit must not mutate a shared allocation"
+        );
+        assert_eq!(&*before, "ab\ncd");
+        assert_eq!(buffer.text(), "ab\nxy\ncd");
+    }
 }

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -30,8 +30,8 @@ fn upsert_reuses_input_for_equivalent_paths() {
     use std::path::Path;
 
     let mut db = IncrementalDatabase::new();
-    let a = db.upsert_file(Path::new("/work/a.jl"), "f(x)\n".into());
-    let b = db.upsert_file(Path::new("/work/./a.jl"), "g(x)\n".into());
+    let a = db.upsert_file(Path::new("/work/a.jl"), "f(x)\n");
+    let b = db.upsert_file(Path::new("/work/./a.jl"), "g(x)\n");
     assert!(a == b, "equivalent path spellings should reuse one input");
     assert_eq!(parsed_tree_root(&db, a).to_string(), "g(x)\n");
 }
@@ -99,7 +99,7 @@ fn parse_populates_and_refreshes_the_reparse_base() {
 
     parsed_tree_root(&db, file);
     let prev = db.reparse_prev(file).expect("first parse stores its base");
-    assert_eq!(prev.text, "x = 1\n");
+    assert_eq!(&*prev.text, "x = 1\n");
     assert_eq!(prev.green.to_string(), "x = 1\n");
     assert!(prev.diagnostics.is_empty());
 
@@ -108,7 +108,7 @@ fn parse_populates_and_refreshes_the_reparse_base() {
     db.set_file_text(file, "x = 1 + 2\n");
     parsed_tree_root(&db, file);
     let prev = db.reparse_prev(file).expect("reparse base survives edits");
-    assert_eq!(prev.text, "x = 1 + 2\n");
+    assert_eq!(&*prev.text, "x = 1 + 2\n");
     assert_eq!(prev.green.to_string(), "x = 1 + 2\n");
 }
 
@@ -328,7 +328,7 @@ fn a_stage_after_a_peek_survives_the_drain() {
     db.reparse_store(
         file,
         PrevParse {
-            text: "alphaX = 1\n".to_string(),
+            text: "alphaX = 1\n".into(),
             green: parse("alphaX = 1\n").cst.green().to_owned(),
             diagnostics: Vec::new(),
         },

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -112,6 +112,49 @@ fn parse_populates_and_refreshes_the_reparse_base() {
     assert_eq!(prev.green.to_string(), "x = 1 + 2\n");
 }
 
+/// An upsert whose text equals the tracked input must not bump the revision:
+/// salsa's setter never compares, so `upsert_file`'s guard is the only thing
+/// keeping a no-op write from invalidating every memo. Both routes must hold —
+/// the same shared allocation (the `Arc::ptr_eq` fast path) and a fresh, equal
+/// allocation (the content compare behind it).
+#[test]
+fn an_unchanged_upsert_keeps_the_memos() {
+    use std::path::Path;
+
+    let mut db = IncrementalDatabase::new();
+    let file = db.upsert_file(Path::new("/work/noop.jl"), "x = 1\n");
+    let before = semantic_model(&db, file) as *const _;
+
+    let shared = file.text(&db).clone();
+    db.upsert_file(Path::new("/work/noop.jl"), shared);
+    assert!(
+        std::ptr::eq(before, semantic_model(&db, file)),
+        "re-upserting the tracked allocation must not invalidate"
+    );
+
+    db.upsert_file(Path::new("/work/noop.jl"), "x = 1\n");
+    assert!(
+        std::ptr::eq(before, semantic_model(&db, file)),
+        "re-upserting equal text from a fresh allocation must not invalidate"
+    );
+}
+
+/// The reparse base stores the very allocation salsa tracks, so writing the
+/// base after a parse costs a refcount bump, never a copy of the text.
+#[test]
+fn the_reparse_base_shares_the_tracked_text() {
+    use std::sync::Arc;
+
+    let db = IncrementalDatabase::new();
+    let file = db.add_file("x = 1\n");
+    parsed_tree_root(&db, file);
+    let prev = db.reparse_prev(file).expect("first parse stores its base");
+    assert!(
+        Arc::ptr_eq(&prev.text, file.text(&db)),
+        "the base must share salsa's allocation, not copy it"
+    );
+}
+
 /// Two identifier edits far apart: `diff_edit` would collapse them into one
 /// span covering both statements, so this is the shape only the staged chain
 /// rescues. Whichever route wins, the tree must equal a full parse.

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -155,6 +155,32 @@ fn the_reparse_base_shares_the_tracked_text() {
     );
 }
 
+/// The same no-op contract on the disk-revert path — the one staleness guard
+/// that can take no `Arc::ptr_eq` shortcut, because its text is always a fresh
+/// read. Only the content compare stands between closing an unmodified buffer
+/// and throwing away every memo for that file.
+#[test]
+fn reverting_to_identical_disk_text_keeps_the_memos() {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let path = dir.path().join("same.jl");
+    std::fs::write(&path, "x = 1\ny = x\n").expect("write the file");
+
+    let mut db = IncrementalDatabase::new();
+    let file = db.upsert_file(&path, "x = 1\ny = x\n");
+    let before = semantic_model(&db, file) as *const _;
+
+    db.revert_file_to_disk(&path);
+    assert!(
+        std::ptr::eq(before, semantic_model(&db, file)),
+        "reverting to text the db already tracks must not invalidate"
+    );
+
+    // The guard must still let a genuine on-disk change through.
+    std::fs::write(&path, "x = 2\n").expect("rewrite the file");
+    db.revert_file_to_disk(&path);
+    assert_eq!(db.file_text(file), "x = 2\n");
+}
+
 /// Two identifier edits far apart: `diff_edit` would collapse them into one
 /// span covering both statements, so this is the shape only the staged chain
 /// rescues. Whichever route wins, the tree must equal a full parse.


### PR DESCRIPTION
**What and why**

A keystroke used to copy the document text several times: `PrevParse { text: text.clone() }` per parse, `buffer.text().to_string()` per analysis dispatch, and an O(N) memcmp per staleness check. This shares one allocation across the live buffer, salsa's `SourceFile`, and the reparse base, so those become refcount bumps and `Arc::ptr_eq` checks. Separately, `Token` owned a `String` per token; token text is always a verbatim slice of the input, so it now borrows (`Token<'src> { text: &'src str }`).

Measured on Linux x86, otherwise-idle, criterion medians and the new pipeline bench:

| bench | before | after |
|---|---|---|
| `lex_corpus` | 980 µs | 343 µs (−65%) |
| `lex_operators` | 1.337 ms | 549 µs (−59%) |
| `lex_field_access` | 663 µs | 254 µs (−62%) |
| `full_parse` | 5.51 ms | 4.63 ms (−16%) |
| parse full, 1 MB | 34.9 ms | 29.9 ms (−14%) |
| no-op upsert, 1 MB | 39 µs | 150 ns |

**Approach**

Three pieces, atomic per area:

1. **`Token<'src>` borrows its text.** One production site (`Lexer::push`) drops the `.to_string()`; the rest is lifetime threading that elision handles almost everywhere. No public API change (`Token`/`lex` are `pub(crate)`), and no reparse logic changes — tokens never outlive the parse call.
2. **`Arc<str>` document text.** `TextBuffer` holds `Arc<str>` beside the maintained `LineStarts`; `SourceFile.text` and `PrevParse.text` share that allocation. Setters take `impl Into<Arc<str>>`. The staleness guards get `Arc::ptr_eq` **in front of** the content compare, never instead of it — salsa's setter does no equality check, so the compare is what stops a no-op write from invalidating every memo.
3. **`benches/salsa_keystroke.rs`**, timing the didChange → upsert → parse path end to end.

Trade-offs, both deliberate:

- **An edit rebuilds the string** rather than splicing in place, since the allocation is shared: +10–30 µs per keystroke at 1 MB, against a reparse that costs 150 µs+ at that size. That is why `benches/line_index.rs`'s didChange row got *worse* in this PR; its header now says so and points at the pipeline bench, which is where the whole trade is visible.
- **The pre-reserve I tried for the token vector is not here.** Julia measures 4.46 bytes/token, but `with_capacity(len/4)` was ~3.5% better on the real-code corpus and ~2% worse on the operator-dense one — a wash, so it stays out rather than ship a constant I can't justify.

**Relationship to #85**

#85 proposes a ropey-backed buffer over the same paths, and this PR exists because of it: the per-token `String` was found by that work, and this is the rust-analyzer-shaped alternative it prompted me to measure. Credit for the insight belongs there.

The two are alternatives, not complements, and the decision between them is separate from this PR. What the pipeline bench says, running both branches with only its one-line `handoff()` flipped: the rope reproduces none of the lexer win that borrowing alone gives (its chunk machinery costs 10–19% against `&str` tokens), and it cannot match `ptr_eq` on the unchanged-text check because rope equality walks chunks (27 µs at 1 MB). What a rope uniquely buys is the didChange splice — 0.7 µs flat at 1 MB against this PR's ~34 µs rebuild, which is real and which nothing here reproduces. `TODO.md` records that comparison so the deferral rests on measurement rather than argument.

**Follow-up this surfaced** (not in this PR): `parsed_document` declines a staged chain below two edits, so an ordinary one-keystroke edit always re-derives, by diffing the two whole texts, the edit the server just handed it — ~200 µs of a ~500 µs keystroke at 1 MB, more than the token-tier reparse it feeds. Tracked in `TODO.md`; it helps whichever text representation wins.

**Checklist**

- [x] Added or updated tests (test-first; a bug fix has a failing fixture that now passes)
- [x] `cargo test` passes (`--workspace`, 29 suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt -- --check` is clean
- [x] Reviewed changed snapshots (`cargo insta review`), if any — none changed
- [x] Commits follow Conventional Commits
