### PR TITLE
chore(release): v0.16.0 (+4 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,58 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "706e1d65e13e334ff3c40b9b876e10b5e5ed8c45",
+  "baseline-sha": "925105c85427b665ca97b11dd59a7338793732ed",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.15.0",
-      "tag": "v0.15.0"
+      "version": "0.16.0",
+      "tag": "v0.16.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.3",
-      "tag": "fatou-formatter-v0.3.3"
+      "version": "0.4.0",
+      "tag": "fatou-formatter-v0.4.0"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.4.1",
-      "tag": "fatou-parser-v0.4.1"
+      "version": "0.5.0",
+      "tag": "fatou-parser-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.15.0",
-      "tag": "fatou-code-v0.15.0"
+      "version": "0.16.0",
+      "tag": "fatou-code-v0.16.0"
+    },
+    {
+      "path": "editors/zed",
+      "version": "0.2.0",
+      "tag": "fatou-zed-v0.2.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.15.0",
-      "tag": "v0.15.0"
+      "version": "0.16.0",
+      "tag": "v0.16.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.3.3",
-      "tag": "fatou-formatter-v0.3.3"
+      "version": "0.4.0",
+      "tag": "fatou-formatter-v0.4.0"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.4.1",
-      "tag": "fatou-parser-v0.4.1"
+      "version": "0.5.0",
+      "tag": "fatou-parser-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.15.0",
-      "tag": "fatou-code-v0.15.0"
+      "version": "0.16.0",
+      "tag": "fatou-code-v0.16.0"
+    },
+    {
+      "path": "editors/zed",
+      "version": "0.2.0",
+      "tag": "fatou-zed-v0.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/fatou/compare/v0.15.0...v0.16.0) (2026-08-25)
+
+### Features
+- **formatter:** hug bracketed splats ([`d5da2eb`](https://github.com/jolars/fatou/commit/d5da2eb121b09747fb87e336bd9cb63938d19989))
+- **parser:** parse nested macro loop arguments ([`1a90dde`](https://github.com/jolars/fatou/commit/1a90dde91544496331d5a5be20b1e998e375a851))
+- **parser:** parse dotted Unicode unary ops ([`406247e`](https://github.com/jolars/fatou/commit/406247e8d66e52df535721870d385fa099e8c999))
+- **parser:** parse spaced operator calls ([`6c3fdf0`](https://github.com/jolars/fatou/commit/6c3fdf066cff69e8d6717384c7d0f95424277820))
+- **parser:** recover parenthesized leading commas ([`1e08166`](https://github.com/jolars/fatou/commit/1e08166c8d00ec3f58d7afa2b8216dbc21a1a194))
+- **parser:** recover leading empty list slots ([`5b5ef49`](https://github.com/jolars/fatou/commit/5b5ef49462952a17b980b3705628e04123153c1e))
+- **parser:** parse var forward declarations ([`9dd14cb`](https://github.com/jolars/fatou/commit/9dd14cbb2af02e16564328c2f4aefff8a8c34558))
+- **parser:** recover quoted import names ([`26ffb4d`](https://github.com/jolars/fatou/commit/26ffb4d9ce421bff93eeb989ad11370acfcf3474))
+- **parser:** recover parenthesized macro signatures ([`3131255`](https://github.com/jolars/fatou/commit/3131255e088ad96407f2bbd5b6ade6cb0515f43c))
+- **parser:** recover bare colon-eq and dot ([`e379a8e`](https://github.com/jolars/fatou/commit/e379a8e1ce5b65641d10915f2ec0ff13c0e7cb07))
+- **parser:** parse command macro numeric args ([`d680355`](https://github.com/jolars/fatou/commit/d680355cf5114435385c1f161d0141b325157eeb))
+- **parser:** parse parenthesized lambda params ([`0809d8c`](https://github.com/jolars/fatou/commit/0809d8c703b1b43c0b6c291c5e199511da4f73b6))
+- **parser:** parse generator parameters ([`e59f76e`](https://github.com/jolars/fatou/commit/e59f76e425a5f2d70d646ee5d8921867676c2b21))
+
+### Bug Fixes
+- **parser:** decode raw triple-string quotes ([`3cac3ae`](https://github.com/jolars/fatou/commit/3cac3ae8643df527c3551680c48422f5e34fe7e8))
+- **parser:** escape triple-string quotes ([`ed55f05`](https://github.com/jolars/fatou/commit/ed55f05effc7a125dd7dace906514d789aa48969))
+- **parser:** preserve nested matrix row order ([`003e88e`](https://github.com/jolars/fatou/commit/003e88e2f8f8b1955a938a6ce4558acfed41ca1d))
+- **parser:** report invalid aliases ([`c08174d`](https://github.com/jolars/fatou/commit/c08174dd8fc5bbf9dca27fcb01c4db1f374d417d))
+
+### Performance Improvements
+- bound formatting diffs ([`ff74f68`](https://github.com/jolars/fatou/commit/ff74f681ff193abfd98eabef54557c49544b1428))
+
+### Dependencies
+- updated crates/fatou-formatter to v0.4.0
+- updated crates/fatou-parser to v0.5.0
+
 ## [0.15.0](https://github.com/jolars/fatou/compare/v0.14.0...v0.15.0) (2026-08-16)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -253,7 +253,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -461,9 +461,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embedded-io"
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -555,7 +555,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
- "similar 3.1.2",
+ "similar 3.2.0",
  "smol_str",
  "tempfile",
  "toml",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "insta",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lsp-server"
@@ -1058,22 +1058,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1204,7 +1204,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1238,7 +1238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1280,7 +1280,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1315,7 +1315,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1341,9 +1341,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
 ]
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1449,7 +1449,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -52,8 +52,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.3.3" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.4.1" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.4.0" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.5.0" }
 globset = "0.4.18"
 ignore = "0.4.26"
 log = { version = "0.4.32", features = ["release_max_level_info"] }

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.3...fatou-formatter-v0.4.0) (2026-08-25)
+
+### Features
+- **formatter:** hug bracketed splats ([`d5da2eb`](https://github.com/jolars/fatou/commit/d5da2eb121b09747fb87e336bd9cb63938d19989))
+
+### Dependencies
+- updated crates/fatou-parser to v0.5.0
+
 ## [0.3.3](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.2...fatou-formatter-v0.3.3) (2026-08-16)
 
 ### Performance Improvements

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.3.3"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.4.1" }
+fatou-parser = { path = "../fatou-parser", version = "0.5.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.4.1...fatou-parser-v0.5.0) (2026-08-25)
+
+### Features
+- **parser:** parse nested macro loop arguments ([`1a90dde`](https://github.com/jolars/fatou/commit/1a90dde91544496331d5a5be20b1e998e375a851))
+- **parser:** parse dotted Unicode unary ops ([`406247e`](https://github.com/jolars/fatou/commit/406247e8d66e52df535721870d385fa099e8c999))
+- **parser:** parse spaced operator calls ([`6c3fdf0`](https://github.com/jolars/fatou/commit/6c3fdf066cff69e8d6717384c7d0f95424277820))
+- **parser:** recover parenthesized leading commas ([`1e08166`](https://github.com/jolars/fatou/commit/1e08166c8d00ec3f58d7afa2b8216dbc21a1a194))
+- **parser:** recover leading empty list slots ([`5b5ef49`](https://github.com/jolars/fatou/commit/5b5ef49462952a17b980b3705628e04123153c1e))
+- **parser:** parse var forward declarations ([`9dd14cb`](https://github.com/jolars/fatou/commit/9dd14cbb2af02e16564328c2f4aefff8a8c34558))
+- **parser:** recover quoted import names ([`26ffb4d`](https://github.com/jolars/fatou/commit/26ffb4d9ce421bff93eeb989ad11370acfcf3474))
+- **parser:** recover parenthesized macro signatures ([`3131255`](https://github.com/jolars/fatou/commit/3131255e088ad96407f2bbd5b6ade6cb0515f43c))
+- **parser:** recover bare colon-eq and dot ([`e379a8e`](https://github.com/jolars/fatou/commit/e379a8e1ce5b65641d10915f2ec0ff13c0e7cb07))
+- **parser:** parse command macro numeric args ([`d680355`](https://github.com/jolars/fatou/commit/d680355cf5114435385c1f161d0141b325157eeb))
+- **parser:** parse parenthesized lambda params ([`0809d8c`](https://github.com/jolars/fatou/commit/0809d8c703b1b43c0b6c291c5e199511da4f73b6))
+- **parser:** parse generator parameters ([`e59f76e`](https://github.com/jolars/fatou/commit/e59f76e425a5f2d70d646ee5d8921867676c2b21))
+- **parser:** finish JuliaSyntax 1.0 migration ([`f53225d`](https://github.com/jolars/fatou/commit/f53225df9834dd0d5d8006a784c7c33b623f4ff2))
+
+### Bug Fixes
+- **parser:** lex U+1F8B2 as an arrow operator ([`ede624d`](https://github.com/jolars/fatou/commit/ede624dbc3c29aa904599158a6b0f9f562ea06aa))
+- **parser:** project every field-access right operand ([`b544757`](https://github.com/jolars/fatou/commit/b544757e310712fcbd0610c9806a3925e937084e))
+- **parser:** keep `do` clauses off non-call heads ([`2c3295c`](https://github.com/jolars/fatou/commit/2c3295cb433054bd01cf60145c69e6f261d7ba31))
+- **parser:** report an unclosed leading-comma paren ([`9c8208d`](https://github.com/jolars/fatou/commit/9c8208d07ede2e125e32d8e8b47782bf7ec6f3d1))
+- **parser:** stop operators reaching past a line comment ([`3d410b8`](https://github.com/jolars/fatou/commit/3d410b8aea1dc2398e0e4f6b85d8fc402831b9eb))
+- **parser:** decode raw triple-string quotes ([`3cac3ae`](https://github.com/jolars/fatou/commit/3cac3ae8643df527c3551680c48422f5e34fe7e8))
+- **parser:** escape triple-string quotes ([`ed55f05`](https://github.com/jolars/fatou/commit/ed55f05effc7a125dd7dace906514d789aa48969))
+- **parser:** preserve nested matrix row order ([`003e88e`](https://github.com/jolars/fatou/commit/003e88e2f8f8b1955a938a6ce4558acfed41ca1d))
+- **parser:** report invalid aliases ([`c08174d`](https://github.com/jolars/fatou/commit/c08174dd8fc5bbf9dca27fcb01c4db1f374d417d))
+
+### Performance Improvements
+- **parser:** take an operator's last char in `O(1)` ([`fd6acfd`](https://github.com/jolars/fatou/commit/fd6acfd6e37fc6611d3b405ca860381e61b712fc))
+
 ## [0.4.1](https://github.com/jolars/fatou/compare/fatou-parser-v0.4.0...fatou-parser-v0.4.1) (2026-08-16)
 
 ### Bug Fixes

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/fatou/compare/fatou-code-v0.15.0...fatou-code-v0.16.0) (2026-08-25)
+
+### Dependencies
+- updated fatou to v0.16.0
+
 ## [0.15.0](https://github.com/jolars/fatou/compare/fatou-code-v0.14.0...fatou-code-v0.15.0) (2026-08-16)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/CHANGELOG.md
+++ b/editors/zed/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/fatou/compare/fatou-zed-v0.1.0...fatou-zed-v0.2.0) (2026-08-25)
+
+### Features
+- **editors:** add zed extension ([`1b80c59`](https://github.com/jolars/fatou/commit/1b80c593eacaa47a7b82a5d6506b4f7fd06eb535))

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "zed_fatou"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_fatou"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "fatou-language-server"
 name = "Fatou"
 description = "Language server, formatter, and linter for Julia"
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Johan Larsson <johan@jolars.co>"]
 repository = "https://github.com/jolars/fatou"

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.15.0",
-    "@fatou-cli/linux-arm64-gnu": "0.15.0",
-    "@fatou-cli/linux-x64-musl": "0.15.0",
-    "@fatou-cli/linux-arm64-musl": "0.15.0",
-    "@fatou-cli/darwin-x64": "0.15.0",
-    "@fatou-cli/darwin-arm64": "0.15.0",
-    "@fatou-cli/win32-x64": "0.15.0",
-    "@fatou-cli/win32-arm64": "0.15.0"
+    "@fatou-cli/linux-x64-gnu": "0.16.0",
+    "@fatou-cli/linux-arm64-gnu": "0.16.0",
+    "@fatou-cli/linux-x64-musl": "0.16.0",
+    "@fatou-cli/linux-arm64-musl": "0.16.0",
+    "@fatou-cli/darwin-x64": "0.16.0",
+    "@fatou-cli/darwin-arm64": "0.16.0",
+    "@fatou-cli/win32-x64": "0.16.0",
+    "@fatou-cli/win32-arm64": "0.16.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.16.0](https://github.com/jolars/fatou/compare/v0.15.0...v0.16.0) (2026-08-25)

### Features
- **formatter:** hug bracketed splats ([`d5da2eb`](https://github.com/jolars/fatou/commit/d5da2eb121b09747fb87e336bd9cb63938d19989))
- **parser:** parse nested macro loop arguments ([`1a90dde`](https://github.com/jolars/fatou/commit/1a90dde91544496331d5a5be20b1e998e375a851))
- **parser:** parse dotted Unicode unary ops ([`406247e`](https://github.com/jolars/fatou/commit/406247e8d66e52df535721870d385fa099e8c999))
- **parser:** parse spaced operator calls ([`6c3fdf0`](https://github.com/jolars/fatou/commit/6c3fdf066cff69e8d6717384c7d0f95424277820))
- **parser:** recover parenthesized leading commas ([`1e08166`](https://github.com/jolars/fatou/commit/1e08166c8d00ec3f58d7afa2b8216dbc21a1a194))
- **parser:** recover leading empty list slots ([`5b5ef49`](https://github.com/jolars/fatou/commit/5b5ef49462952a17b980b3705628e04123153c1e))
- **parser:** parse var forward declarations ([`9dd14cb`](https://github.com/jolars/fatou/commit/9dd14cbb2af02e16564328c2f4aefff8a8c34558))
- **parser:** recover quoted import names ([`26ffb4d`](https://github.com/jolars/fatou/commit/26ffb4d9ce421bff93eeb989ad11370acfcf3474))
- **parser:** recover parenthesized macro signatures ([`3131255`](https://github.com/jolars/fatou/commit/3131255e088ad96407f2bbd5b6ade6cb0515f43c))
- **parser:** recover bare colon-eq and dot ([`e379a8e`](https://github.com/jolars/fatou/commit/e379a8e1ce5b65641d10915f2ec0ff13c0e7cb07))
- **parser:** parse command macro numeric args ([`d680355`](https://github.com/jolars/fatou/commit/d680355cf5114435385c1f161d0141b325157eeb))
- **parser:** parse parenthesized lambda params ([`0809d8c`](https://github.com/jolars/fatou/commit/0809d8c703b1b43c0b6c291c5e199511da4f73b6))
- **parser:** parse generator parameters ([`e59f76e`](https://github.com/jolars/fatou/commit/e59f76e425a5f2d70d646ee5d8921867676c2b21))

### Bug Fixes
- **parser:** decode raw triple-string quotes ([`3cac3ae`](https://github.com/jolars/fatou/commit/3cac3ae8643df527c3551680c48422f5e34fe7e8))
- **parser:** escape triple-string quotes ([`ed55f05`](https://github.com/jolars/fatou/commit/ed55f05effc7a125dd7dace906514d789aa48969))
- **parser:** preserve nested matrix row order ([`003e88e`](https://github.com/jolars/fatou/commit/003e88e2f8f8b1955a938a6ce4558acfed41ca1d))
- **parser:** report invalid aliases ([`c08174d`](https://github.com/jolars/fatou/commit/c08174dd8fc5bbf9dca27fcb01c4db1f374d417d))

### Performance Improvements
- bound formatting diffs ([`ff74f68`](https://github.com/jolars/fatou/commit/ff74f681ff193abfd98eabef54557c49544b1428))

### Dependencies
- updated crates/fatou-formatter to v0.4.0
- updated crates/fatou-parser to v0.5.0

## [crates/fatou-formatter: 0.4.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.3...fatou-formatter-v0.4.0) (2026-08-25)

### Features
- **formatter:** hug bracketed splats ([`d5da2eb`](https://github.com/jolars/fatou/commit/d5da2eb121b09747fb87e336bd9cb63938d19989))

### Dependencies
- updated crates/fatou-parser to v0.5.0

## [crates/fatou-parser: 0.5.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.4.1...fatou-parser-v0.5.0) (2026-08-25)

### Features
- **parser:** parse nested macro loop arguments ([`1a90dde`](https://github.com/jolars/fatou/commit/1a90dde91544496331d5a5be20b1e998e375a851))
- **parser:** parse dotted Unicode unary ops ([`406247e`](https://github.com/jolars/fatou/commit/406247e8d66e52df535721870d385fa099e8c999))
- **parser:** parse spaced operator calls ([`6c3fdf0`](https://github.com/jolars/fatou/commit/6c3fdf066cff69e8d6717384c7d0f95424277820))
- **parser:** recover parenthesized leading commas ([`1e08166`](https://github.com/jolars/fatou/commit/1e08166c8d00ec3f58d7afa2b8216dbc21a1a194))
- **parser:** recover leading empty list slots ([`5b5ef49`](https://github.com/jolars/fatou/commit/5b5ef49462952a17b980b3705628e04123153c1e))
- **parser:** parse var forward declarations ([`9dd14cb`](https://github.com/jolars/fatou/commit/9dd14cbb2af02e16564328c2f4aefff8a8c34558))
- **parser:** recover quoted import names ([`26ffb4d`](https://github.com/jolars/fatou/commit/26ffb4d9ce421bff93eeb989ad11370acfcf3474))
- **parser:** recover parenthesized macro signatures ([`3131255`](https://github.com/jolars/fatou/commit/3131255e088ad96407f2bbd5b6ade6cb0515f43c))
- **parser:** recover bare colon-eq and dot ([`e379a8e`](https://github.com/jolars/fatou/commit/e379a8e1ce5b65641d10915f2ec0ff13c0e7cb07))
- **parser:** parse command macro numeric args ([`d680355`](https://github.com/jolars/fatou/commit/d680355cf5114435385c1f161d0141b325157eeb))
- **parser:** parse parenthesized lambda params ([`0809d8c`](https://github.com/jolars/fatou/commit/0809d8c703b1b43c0b6c291c5e199511da4f73b6))
- **parser:** parse generator parameters ([`e59f76e`](https://github.com/jolars/fatou/commit/e59f76e425a5f2d70d646ee5d8921867676c2b21))
- **parser:** finish JuliaSyntax 1.0 migration ([`f53225d`](https://github.com/jolars/fatou/commit/f53225df9834dd0d5d8006a784c7c33b623f4ff2))

### Bug Fixes
- **parser:** lex U+1F8B2 as an arrow operator ([`ede624d`](https://github.com/jolars/fatou/commit/ede624dbc3c29aa904599158a6b0f9f562ea06aa))
- **parser:** project every field-access right operand ([`b544757`](https://github.com/jolars/fatou/commit/b544757e310712fcbd0610c9806a3925e937084e))
- **parser:** keep `do` clauses off non-call heads ([`2c3295c`](https://github.com/jolars/fatou/commit/2c3295cb433054bd01cf60145c69e6f261d7ba31))
- **parser:** report an unclosed leading-comma paren ([`9c8208d`](https://github.com/jolars/fatou/commit/9c8208d07ede2e125e32d8e8b47782bf7ec6f3d1))
- **parser:** stop operators reaching past a line comment ([`3d410b8`](https://github.com/jolars/fatou/commit/3d410b8aea1dc2398e0e4f6b85d8fc402831b9eb))
- **parser:** decode raw triple-string quotes ([`3cac3ae`](https://github.com/jolars/fatou/commit/3cac3ae8643df527c3551680c48422f5e34fe7e8))
- **parser:** escape triple-string quotes ([`ed55f05`](https://github.com/jolars/fatou/commit/ed55f05effc7a125dd7dace906514d789aa48969))
- **parser:** preserve nested matrix row order ([`003e88e`](https://github.com/jolars/fatou/commit/003e88e2f8f8b1955a938a6ce4558acfed41ca1d))
- **parser:** report invalid aliases ([`c08174d`](https://github.com/jolars/fatou/commit/c08174dd8fc5bbf9dca27fcb01c4db1f374d417d))

### Performance Improvements
- **parser:** take an operator's last char in `O(1)` ([`fd6acfd`](https://github.com/jolars/fatou/commit/fd6acfd6e37fc6611d3b405ca860381e61b712fc))

## [editors/code: 0.16.0](https://github.com/jolars/fatou/compare/fatou-code-v0.15.0...fatou-code-v0.16.0) (2026-08-25)

### Dependencies
- updated fatou to v0.16.0

## [editors/zed: 0.2.0](https://github.com/jolars/fatou/compare/fatou-zed-v0.1.0...fatou-zed-v0.2.0) (2026-08-25)

### Features
- **editors:** add zed extension ([`1b80c59`](https://github.com/jolars/fatou/commit/1b80c593eacaa47a7b82a5d6506b4f7fd06eb535))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).