### PR TITLE
chore(release): v0.17.0 (+2 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "925105c85427b665ca97b11dd59a7338793732ed",
+  "baseline-sha": "141edd9a51a5f8c15800047d83305a44c5784ad1",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.4.0",
-      "tag": "fatou-formatter-v0.4.0"
+      "version": "0.5.0",
+      "tag": "fatou-formatter-v0.5.0"
     },
     {
       "path": "crates/fatou-parser",
@@ -19,8 +19,8 @@
     },
     {
       "path": "editors/code",
-      "version": "0.16.0",
-      "tag": "fatou-code-v0.16.0"
+      "version": "0.17.0",
+      "tag": "fatou-code-v0.17.0"
     },
     {
       "path": "editors/zed",
@@ -31,28 +31,18 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.4.0",
-      "tag": "fatou-formatter-v0.4.0"
-    },
-    {
-      "path": "crates/fatou-parser",
       "version": "0.5.0",
-      "tag": "fatou-parser-v0.5.0"
+      "tag": "fatou-formatter-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.16.0",
-      "tag": "fatou-code-v0.16.0"
-    },
-    {
-      "path": "editors/zed",
-      "version": "0.2.0",
-      "tag": "fatou-zed-v0.2.0"
+      "version": "0.17.0",
+      "tag": "fatou-code-v0.17.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/fatou/compare/v0.16.0...v0.17.0) (2026-08-26)
+
+### Features
+- **formatter:** align trailing comments ([`132272b`](https://github.com/jolars/fatou/commit/132272b3ccfe076a8eb8eff261e021e524d9c9b6))
+
+### Dependencies
+- updated crates/fatou-formatter to v0.5.0
+
 ## [0.16.0](https://github.com/jolars/fatou/compare/v0.15.0...v0.16.0) (2026-08-25)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "fatou-parser",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -49,7 +49,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.4.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.5.0" }
 fatou-parser = { path = "crates/fatou-parser", version = "0.5.0" }
 globset = "0.4.18"
 ignore = "0.4.26"

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.4.0...fatou-formatter-v0.5.0) (2026-08-26)
+
+### Features
+- **formatter:** align trailing comments ([`132272b`](https://github.com/jolars/fatou/commit/132272b3ccfe076a8eb8eff261e021e524d9c9b6))
+
 ## [0.4.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.3.3...fatou-formatter-v0.4.0) (2026-08-25)
 
 ### Features

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/fatou/compare/fatou-code-v0.16.0...fatou-code-v0.17.0) (2026-08-26)
+
+### Bug Fixes
+- **code:** align VS Code API types ([`74d0970`](https://github.com/jolars/fatou/commit/74d097088a7fd4bbea91610a2b05c4e7757b5260))
+
+### Dependencies
+- updated fatou to v0.17.0
+
 ## [0.16.0](https://github.com/jolars/fatou/compare/fatou-code-v0.15.0...fatou-code-v0.16.0) (2026-08-25)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.16.0",
-    "@fatou-cli/linux-arm64-gnu": "0.16.0",
-    "@fatou-cli/linux-x64-musl": "0.16.0",
-    "@fatou-cli/linux-arm64-musl": "0.16.0",
-    "@fatou-cli/darwin-x64": "0.16.0",
-    "@fatou-cli/darwin-arm64": "0.16.0",
-    "@fatou-cli/win32-x64": "0.16.0",
-    "@fatou-cli/win32-arm64": "0.16.0"
+    "@fatou-cli/linux-x64-gnu": "0.17.0",
+    "@fatou-cli/linux-arm64-gnu": "0.17.0",
+    "@fatou-cli/linux-x64-musl": "0.17.0",
+    "@fatou-cli/linux-arm64-musl": "0.17.0",
+    "@fatou-cli/darwin-x64": "0.17.0",
+    "@fatou-cli/darwin-arm64": "0.17.0",
+    "@fatou-cli/win32-x64": "0.17.0",
+    "@fatou-cli/win32-arm64": "0.17.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.17.0](https://github.com/jolars/fatou/compare/v0.16.0...v0.17.0) (2026-08-26)

### Features
- **formatter:** align trailing comments ([`132272b`](https://github.com/jolars/fatou/commit/132272b3ccfe076a8eb8eff261e021e524d9c9b6))

### Dependencies
- updated crates/fatou-formatter to v0.5.0

## [crates/fatou-formatter: 0.5.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.4.0...fatou-formatter-v0.5.0) (2026-08-26)

### Features
- **formatter:** align trailing comments ([`132272b`](https://github.com/jolars/fatou/commit/132272b3ccfe076a8eb8eff261e021e524d9c9b6))

## [editors/code: 0.17.0](https://github.com/jolars/fatou/compare/fatou-code-v0.16.0...fatou-code-v0.17.0) (2026-08-26)

### Bug Fixes
- **code:** align VS Code API types ([`74d0970`](https://github.com/jolars/fatou/commit/74d097088a7fd4bbea91610a2b05c4e7757b5260))

### Dependencies
- updated fatou to v0.17.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).