### PR TITLE
feat(formatter): verify formatting preserves the program with ast_shape

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,46 @@
   `A \ b`). Fixture `left_division` proves canonical spacing, width-driven
   continuation, and uniform breaks across the shared `*`/`\`/`/` tier.
 
+- [ ] Stop dropping a trailing `;` inside brackets — it collapses a
+  concatenation into a container literal. `[x;]` (`vcat`) formats to `[x]`
+  (`vect`), `[;]` to `[]`, `{x;}` to `{x}`; for a non-scalar element these are
+  different values (`[1:70;]` is a 70-element `Vector{Int}`, `[1:70]` a
+  1-element `Vector{UnitRange{Int}}`). The typed forms are worse: `T[x;]`
+  (`typed_vcat`) becomes `T[x]`, which projects as `ref` — indexing `T` rather
+  than constructing it. Listed in `tests/ast-equivalence/known-drift.txt` under
+  the bracket-semicolon group; drop those entries with the fix.
+
+- [ ] Stop dropping the trailing comma of an operator call — it turns the call
+  into a prefix operator application. `+(a=1,)` (`(call + (= a 1))`, a keyword
+  argument) formats to `+(a = 1)` (`(call-pre + (= a 1))`, unary plus applied to
+  an assignment); same for `<:(a,)`, `>:(a,)`, `.+(a,)`. Unlike a trailing comma
+  in an ordinary call, this one is load-bearing. Listed in
+  `tests/ast-equivalence/known-drift.txt`.
+
+- [ ] Stop removing whitespace between a macro's arguments — it changes arity.
+  `@foo a [1]` (two arguments, `a` and `[1]`) formats to `@foo a[1]` (one
+  argument, `a[1]`); same for `@foo A {T}` and `@foo g(x) [1]`. For a macro the
+  argument list is the input, so this rewrites the call. Fixture
+  `macro_space_args` in the parser oracle corpus; listed in
+  `tests/ast-equivalence/known-drift.txt`.
+
+- [ ] Fix the `where` brace canonicalization double-wrapping a parameter list
+  that is already braced but does not project as `braces`: `x where {T S}` →
+  `x where {{T S}}`, `x where {y for y in ys}` → `x where {{y for y in ys}}`.
+  Listed in `tests/ast-equivalence/known-drift.txt`.
+
+- [ ] Fix hex literal zero-padding counting `_` as a digit: `0x1_2` → `0x01_2`
+  widens a 2-digit `UInt8` literal to a 3-digit `UInt16`. Padding is otherwise
+  type-preserving, which `formatter_preserves_ast_shape` proves — the projector
+  renders a hex literal at its type's width, so only this row drifts. Fixture
+  `hex_literals`.
+
+- [ ] Decide the policy for folding a spaced unary minus into its literal
+  (`- 2` → `-2`). Value-identical except at a type boundary:
+  `- 9223372036854775808` negates an `Int128` literal, while
+  `-9223372036854775808` is the `Int64` `typemin`. Listed in
+  `tests/ast-equivalence/known-drift.txt` as `js-84685b8e`.
+
 ## Linter
 
 ### Rules

--- a/crates/fatou-formatter/src/lib.rs
+++ b/crates/fatou-formatter/src/lib.rs
@@ -13,6 +13,8 @@
 //!   [`fatou_parser::syntax::SyntaxNode`], whole or a byte range of it.
 //! - [`FormatStyle`] — the layout knobs, with [`Default`] matching the fatou
 //!   CLI's defaults.
+//! - [`verify::ast_shape`] — the formatting-invariant shape of a source string,
+//!   for checking that formatting preserved the program (`ast(x) == ast(format(x))`).
 //!
 //! The crate is `wasm32-unknown-unknown`-compatible: no filesystem, process,
 //! thread, or clock use.
@@ -28,6 +30,7 @@ pub mod formatter;
 
 pub mod parser;
 pub mod syntax;
+pub mod verify;
 
 /// The `rowan` version this crate's CST types are built on.
 ///

--- a/crates/fatou-formatter/src/verify.rs
+++ b/crates/fatou-formatter/src/verify.rs
@@ -34,7 +34,10 @@
 //! `x where {{T S}}`. They are recorded as known-drift entries in the tests
 //! instead, where they stay visible and attributable.
 
-use fatou_parser::parser::{normalize_sexpr, parse, to_juliasyntax_sexpr};
+use fatou_parser::parser::{parse, sexpr_tokens, to_juliasyntax_sexpr};
+
+/// The projector's sentinel head for a `SyntaxKind` it cannot render.
+const UNSUPPORTED: &str = "unsupported";
 
 /// The formatting-invariant shape of `text`, or `None` when no comparable shape
 /// exists.
@@ -64,38 +67,49 @@ pub fn ast_shape(text: &str) -> Option<String> {
         return None;
     }
     let raw = to_juliasyntax_sexpr(&output.cst, &output.diagnostics);
-    if raw.contains("(unsupported ") {
+    let mut tokens = sexpr_tokens(&raw);
+    if tokens
+        .iter()
+        .enumerate()
+        .any(|(i, t)| is_head(&tokens, i) && t == UNSUPPORTED)
+    {
         return None;
     }
-    Some(drop_surface_flags(&normalize_sexpr(&raw)))
+    drop_surface_flags(&mut tokens);
+    Some(tokens.join(" "))
 }
 
-/// Strip the licensed surface flags from a [`normalize_sexpr`] token stream.
+/// Whether `tokens[i]` is a head — the token directly after a `(`.
+fn is_head(tokens: &[String], i: usize) -> bool {
+    i > 0 && tokens[i - 1] == "("
+}
+
+/// Strip the licensed surface flags from a projection's tokens.
 ///
-/// Operates on head tokens only — the token directly after a `(` — so an atom
-/// that happens to end in the flag's spelling is never touched. `normalize_sexpr`
-/// has already collapsed `"…"` string literals into single atoms, so splitting
-/// on spaces cannot cut one apart.
-fn drop_surface_flags(normalized: &str) -> String {
-    let mut out = String::with_capacity(normalized.len());
-    let mut head = false;
-    for token in normalized.split(' ') {
-        if !out.is_empty() {
-            out.push(' ');
+/// Operates on head tokens only, so an atom that happens to end in the flag's
+/// spelling is never touched. Both this and the sentinel check above work from
+/// [`sexpr_tokens`] rather than from the joined string: a string literal is one
+/// token that may itself contain spaces and parentheses, so re-splitting the
+/// join would cut one apart and read its contents as syntax.
+fn drop_surface_flags(tokens: &mut [String]) {
+    for i in 0..tokens.len() {
+        if is_head(tokens, i)
+            && let Some(stripped) = tokens[i].strip_suffix("-,")
+        {
+            tokens[i] = stripped.to_string();
         }
-        if head && let Some(stripped) = token.strip_suffix("-,") {
-            out.push_str(stripped);
-        } else {
-            out.push_str(token);
-        }
-        head = token == "(";
     }
-    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn strip(normalized: &str) -> String {
+        let mut tokens = sexpr_tokens(normalized);
+        drop_surface_flags(&mut tokens);
+        tokens.join(" ")
+    }
 
     #[test]
     fn layout_does_not_move_the_shape() {
@@ -113,7 +127,16 @@ mod tests {
     fn trailing_comma_flag_is_erased() {
         assert_eq!(ast_shape("f(a,)"), ast_shape("f(a)"));
         assert!(!ast_shape("f(a,)").unwrap().contains("call-,"));
-        assert_eq!(drop_surface_flags("( call-, f a-, )"), "( call f a-, )");
+        assert_eq!(strip("( call-, f a-, )"), "( call f a-, )");
+    }
+
+    /// A string literal's contents are operand text, not syntax: neither the
+    /// erasure nor the sentinel check may read structure out of them.
+    #[test]
+    fn string_contents_are_opaque() {
+        let shape = ast_shape(r#"x = "a ( b-, c""#).expect("string literal has a shape");
+        assert!(shape.contains(r#""a ( b-, c""#), "{shape}");
+        assert!(ast_shape(r#"y = "(unsupported FOO)""#).is_some());
     }
 
     /// A `;` inside brackets is meaning, not layout: `[x;]` is `vcat`.

--- a/crates/fatou-formatter/src/verify.rs
+++ b/crates/fatou-formatter/src/verify.rs
@@ -1,0 +1,135 @@
+//! Formatting-invariant AST shape — the basis of `ast(x) == ast(format(x))`.
+//!
+//! The formatter's other invariants are all *local*: idempotence says a second
+//! pass changes nothing, and a clean reparse says the output is still Julia.
+//! Neither says the output is still the **same program**. [`ast_shape`] closes
+//! that gap: two texts with the same shape denote the same program, so a
+//! fixture whose shape survives formatting is proof the formatter moved only
+//! layout.
+//!
+//! # What the shape is
+//!
+//! The JuliaSyntax s-expression projection
+//! ([`fatou_parser::parser::to_juliasyntax_sexpr`]), whitespace-normalized,
+//! with the surface flags the formatter is licensed to change stripped. The
+//! projector is reused rather than reimplemented: it is the one projection in
+//! the workspace validated differentially against real Julia, and the typed AST
+//! is a read-only *view* over the trivia-bearing CST, not a comparable value.
+//!
+//! # Licensed changes
+//!
+//! The projection mirrors JuliaSyntax's `SyntaxNode`, which records surface
+//! facts below the level of meaning. Exactly one is erased here:
+//!
+//! - **The trailing-comma flag.** JuliaSyntax marks a bracket that closes after
+//!   a trailing comma by suffixing the head (`(call-, f a)`); the formatter adds
+//!   that comma whenever it explodes an argument list across lines. Julia's own
+//!   `Expr` form does not record it.
+//!
+//! Nothing else is normalized, and that is deliberate. `where T` → `where {T}`,
+//! splitting `a; b` onto two lines, and literal canonicalization (`.5` → `0.5`)
+//! are all recorded formatter policies that *do* move the projection, but each
+//! erasure needed to hide them would also hide a real defect — unwrapping
+//! `where` braces, for instance, would conceal `x where {T S}` formatting to
+//! `x where {{T S}}`. They are recorded as known-drift entries in the tests
+//! instead, where they stay visible and attributable.
+
+use fatou_parser::parser::{normalize_sexpr, parse, to_juliasyntax_sexpr};
+
+/// The formatting-invariant shape of `text`, or `None` when no comparable shape
+/// exists.
+///
+/// `None` means the input is outside the invariant's domain, never that the
+/// input is malformed in an interesting way:
+///
+/// - the text does not parse cleanly — formatting an error tree has no defined
+///   equivalence, and the parser's own recovery shapes are not a formatter
+///   concern;
+/// - the projection still contains an `(unsupported …)` sentinel — a
+///   `SyntaxKind` the projector cannot render. Two sentinels compare equal, so
+///   comparing them would be a false pass rather than a check.
+///
+/// Callers deciding between "skipped" and "broken" should parse the formatted
+/// output themselves: a *formatted* text that fails to parse is a formatter
+/// defect, not an out-of-domain input.
+///
+/// # Blind spot
+///
+/// The projection carries no trivia, so a formatter that drops a comment or a
+/// docstring still has a preserved shape. Comment preservation needs its own
+/// check; this one cannot see it.
+pub fn ast_shape(text: &str) -> Option<String> {
+    let output = parse(text);
+    if !output.diagnostics.is_empty() {
+        return None;
+    }
+    let raw = to_juliasyntax_sexpr(&output.cst, &output.diagnostics);
+    if raw.contains("(unsupported ") {
+        return None;
+    }
+    Some(drop_surface_flags(&normalize_sexpr(&raw)))
+}
+
+/// Strip the licensed surface flags from a [`normalize_sexpr`] token stream.
+///
+/// Operates on head tokens only — the token directly after a `(` — so an atom
+/// that happens to end in the flag's spelling is never touched. `normalize_sexpr`
+/// has already collapsed `"…"` string literals into single atoms, so splitting
+/// on spaces cannot cut one apart.
+fn drop_surface_flags(normalized: &str) -> String {
+    let mut out = String::with_capacity(normalized.len());
+    let mut head = false;
+    for token in normalized.split(' ') {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        if head && let Some(stripped) = token.strip_suffix("-,") {
+            out.push_str(stripped);
+        } else {
+            out.push_str(token);
+        }
+        head = token == "(";
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_does_not_move_the_shape() {
+        assert_eq!(ast_shape("f(a,b)"), ast_shape("f(\n    a,\n    b,\n)"));
+        assert_eq!(ast_shape("x = (1 + 2) * 3"), ast_shape("x =\n  (1+2)*3"));
+    }
+
+    #[test]
+    fn precedence_moves_the_shape() {
+        assert_ne!(ast_shape("x = (1 + 2) * 3"), ast_shape("x = 1 + 2 * 3"));
+    }
+
+    /// The one licensed erasure, and its narrowness: only a head is rewritten.
+    #[test]
+    fn trailing_comma_flag_is_erased() {
+        assert_eq!(ast_shape("f(a,)"), ast_shape("f(a)"));
+        assert!(!ast_shape("f(a,)").unwrap().contains("call-,"));
+        assert_eq!(drop_surface_flags("( call-, f a-, )"), "( call f a-, )");
+    }
+
+    /// A `;` inside brackets is meaning, not layout: `[x;]` is `vcat`.
+    #[test]
+    fn bracket_semicolon_moves_the_shape() {
+        assert_ne!(ast_shape("[x;]"), ast_shape("[x]"));
+    }
+
+    #[test]
+    fn out_of_domain_inputs_have_no_shape() {
+        assert_eq!(ast_shape("function f("), None);
+    }
+
+    /// Trivia is invisible to the shape — the documented blind spot.
+    #[test]
+    fn comments_do_not_affect_the_shape() {
+        assert_eq!(ast_shape("f(x)"), ast_shape("# c\nf(x) # d"));
+    }
+}

--- a/crates/fatou-formatter/tests/formatter.rs
+++ b/crates/fatou-formatter/tests/formatter.rs
@@ -21,7 +21,53 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use fatou_formatter::format;
+use fatou_formatter::verify::ast_shape;
 use fatou_parser::parser::parse;
+
+/// Fixtures whose shape the formatter is known to move, each with the reason.
+///
+/// `policy:` entries are recorded formatter behavior that is value- and
+/// type-preserving but visible in the projection. `DEFECT:` entries are bugs
+/// this test found; they stay listed only until they are fixed.
+const KNOWN_DRIFT: &[(&str, &str)] = &[
+    (
+        "broadcast_bitshift",
+        "DEFECT: `[1:70;]` formats to `[1:70]`, turning a `vcat` into a `vect` \
+         (a 70-element `Vector{Int}` becomes a 1-element `Vector{UnitRange{Int}}`)",
+    ),
+    (
+        "float_literals",
+        "policy: float canonicalization (`.5` -> `0.5`, `007.50` -> `7.5`). The \
+         projector renders a float's source spelling, so every row moves; each \
+         rewrite here is value- and type-preserving",
+    ),
+    (
+        "hex_literals",
+        "DEFECT: `0x1_2` formats to `0x01_2` — the zero-padder counts the `_` as \
+         a digit and widens a 2-digit `UInt8` literal to a 3-digit `UInt16`. The \
+         projector renders a hex literal at its type's width, so the other rows \
+         passing is proof the padding is otherwise type-preserving",
+    ),
+    (
+        "toplevel_semicolon",
+        "policy: `a = 1; b = 2` splits onto separate lines, erasing the \
+         `(toplevel-; ...)` grouping. Equivalent in a file; `;` only suppresses \
+         output in the REPL, which fatou does not model",
+    ),
+    (
+        "where_as_identifier",
+        "policy: `where T` canonicalizes to `where {T}` (identical `Expr`)",
+    ),
+    (
+        "where_bare_signature_break",
+        "policy: `where T` canonicalizes to `where {T}` (identical `Expr`)",
+    ),
+    (
+        "where_clauses",
+        "policy: `where T` canonicalizes to `where {T}` (identical `Expr`), as \
+         this fixture's own `expected.jl` asserts",
+    ),
+];
 
 fn fixture_dirs() -> Vec<PathBuf> {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/formatter");
@@ -83,4 +129,59 @@ fn formatter_is_idempotent_and_stable() {
             reparsed.diagnostics
         );
     }
+}
+
+/// AST preservation: formatting moves layout, never the program.
+///
+/// Idempotence and clean reparse are both local — neither says the output still
+/// *means* what the input meant. This compares
+/// [`fatou_formatter::verify::ast_shape`] across the format, over every
+/// `input.jl` (gated or not), so a construct that silently changes meaning fails
+/// here even while its `expected.jl` passes.
+///
+/// `KNOWN_DRIFT` is the exemption list, and it is not an allowlist to grow into:
+/// each entry is either a recorded formatter policy that moves the projection or
+/// a defect this test found. Entries are checked for staleness — a slug that
+/// stops drifting fails until it is removed — so a fixed bug cannot leave its
+/// exemption behind.
+#[test]
+fn formatter_preserves_ast_shape() {
+    let mut drifted = Vec::new();
+    let mut stale = Vec::new();
+
+    for case in fixture_dirs() {
+        let name = slug(&case);
+        let input = fs::read_to_string(case.join("input.jl")).expect("read input.jl");
+        let known = KNOWN_DRIFT.iter().find(|(s, _)| *s == name);
+
+        let Some(before) = ast_shape(&input) else {
+            assert!(
+                known.is_none(),
+                "`{name}` is listed in KNOWN_DRIFT but has no comparable shape"
+            );
+            continue; // out of domain: does not parse cleanly, or projects a sentinel
+        };
+        let formatted = format(&input).expect("format input");
+        let after = ast_shape(&formatted).unwrap_or_else(|| {
+            panic!("formatted output of `{name}` has no comparable shape (it no longer parses)")
+        });
+
+        match (before == after, known) {
+            (false, None) => drifted.push(format!(
+                "{name}\n     before: {before}\n     after:  {after}"
+            )),
+            (true, Some((_, why))) => stale.push(format!("{name} (listed as: {why})")),
+            _ => {}
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "KNOWN_DRIFT entries no longer drift — remove them: {stale:?}"
+    );
+    assert!(
+        drifted.is_empty(),
+        "formatting changed the program shape for:\n  - {}",
+        drifted.join("\n  - ")
+    );
 }

--- a/crates/fatou-formatter/tests/formatter.rs
+++ b/crates/fatou-formatter/tests/formatter.rs
@@ -141,13 +141,15 @@ fn formatter_is_idempotent_and_stable() {
 ///
 /// `KNOWN_DRIFT` is the exemption list, and it is not an allowlist to grow into:
 /// each entry is either a recorded formatter policy that moves the projection or
-/// a defect this test found. Entries are checked for staleness — a slug that
-/// stops drifting fails until it is removed — so a fixed bug cannot leave its
-/// exemption behind.
+/// a defect this test found. Entries are checked for staleness — an entry fails
+/// until it is removed once its slug stops drifting, and equally once its slug
+/// stops naming a fixture — so neither a fixed bug nor a renamed fixture can
+/// leave its exemption behind.
 #[test]
 fn formatter_preserves_ast_shape() {
     let mut drifted = Vec::new();
     let mut stale = Vec::new();
+    let mut exercised = Vec::new();
 
     for case in fixture_dirs() {
         let name = slug(&case);
@@ -161,23 +163,44 @@ fn formatter_preserves_ast_shape() {
             );
             continue; // out of domain: does not parse cleanly, or projects a sentinel
         };
+        exercised.push(name.clone());
         let formatted = format(&input).expect("format input");
+        // The input projected, so a formatted text with no shape is the
+        // formatter's doing — but `ast_shape` folds a failed parse and a
+        // projector sentinel into `None`, and they point at different code.
         let after = ast_shape(&formatted).unwrap_or_else(|| {
-            panic!("formatted output of `{name}` has no comparable shape (it no longer parses)")
+            let diagnostics = parse(&formatted).diagnostics;
+            assert!(
+                !diagnostics.is_empty(),
+                "formatted output of `{name}` parses but no longer projects — the \
+                 formatter produced a construct the projector cannot render"
+            );
+            panic!("formatted output of `{name}` no longer parses cleanly: {diagnostics:?}")
         });
 
         match (before == after, known) {
             (false, None) => drifted.push(format!(
                 "{name}\n     before: {before}\n     after:  {after}"
             )),
-            (true, Some((_, why))) => stale.push(format!("{name} (listed as: {why})")),
+            (true, Some((_, why))) => {
+                stale.push(format!("{name} (no longer drifts; listed as: {why})"))
+            }
             _ => {}
         }
     }
 
+    // An entry no fixture reached is as stale as one that stopped drifting: the
+    // fixture was renamed or deleted, and the exemption now hides nothing.
+    stale.extend(
+        KNOWN_DRIFT
+            .iter()
+            .filter(|(s, _)| !exercised.iter().any(|name| name == s))
+            .map(|(s, why)| format!("{s} (matches no fixture; listed as: {why})")),
+    );
+
     assert!(
         stale.is_empty(),
-        "KNOWN_DRIFT entries no longer drift — remove them: {stale:?}"
+        "KNOWN_DRIFT entries no longer apply — remove them: {stale:?}"
     );
     assert!(
         drifted.is_empty(),

--- a/crates/fatou-parser/src/parser.rs
+++ b/crates/fatou-parser/src/parser.rs
@@ -36,7 +36,7 @@ pub use reparse::{
 // they can never diverge, which is the only reason it is `pub` at all.
 #[doc(hidden)]
 pub use reparse::fingerprint;
-pub use sexpr::{normalize_sexpr, to_juliasyntax_sexpr};
+pub use sexpr::{normalize_sexpr, sexpr_tokens, to_juliasyntax_sexpr};
 // The `lex` bench's entry point. Gated on `bench` so tokenizing on its own —
 // which no consumer has a reason to do — never becomes part of the API.
 #[cfg(feature = "bench")]

--- a/crates/fatou-parser/src/parser/sexpr.rs
+++ b/crates/fatou-parser/src/parser/sexpr.rs
@@ -152,6 +152,19 @@ fn stray_keyword_text(node: &SyntaxNode) -> Option<String> {
 /// and parentheses (preserving `"…"` string literals as atoms) and rejoins with
 /// single-space separation, so pretty-print spacing no longer affects equality.
 pub fn normalize_sexpr(s: &str) -> String {
+    sexpr_tokens(s).join(" ")
+}
+
+/// The token sequence [`normalize_sexpr`] joins: `(` and `)` each on their own,
+/// `"…"` string literals whole (escapes honored), and every other run of
+/// non-delimiter bytes as one atom.
+///
+/// Callers that inspect structure — head position, a sentinel, a head suffix —
+/// must work from this rather than splitting the joined string on spaces: a
+/// string literal is a single token that may itself contain spaces and
+/// parentheses, so re-splitting can cut one apart and mistake its contents for
+/// syntax.
+pub fn sexpr_tokens(s: &str) -> Vec<String> {
     let mut tokens: Vec<String> = Vec::new();
     let bytes = s.as_bytes();
     let mut i = 0usize;
@@ -192,7 +205,7 @@ pub fn normalize_sexpr(s: &str) -> String {
             }
         }
     }
-    tokens.join(" ")
+    tokens
 }
 
 // --- Core dispatch ---------------------------------------------------------
@@ -3551,11 +3564,26 @@ fn is_keyword(kind: SyntaxKind) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::parser::{parse, to_juliasyntax_sexpr};
+    use crate::parser::{normalize_sexpr, parse, sexpr_tokens, to_juliasyntax_sexpr};
 
     fn sexpr(src: &str) -> String {
         let output = parse(src);
         to_juliasyntax_sexpr(&output.cst, &output.diagnostics)
+    }
+
+    /// A string literal is one token however much syntax its contents mimic,
+    /// which is why structural callers tokenize rather than split on spaces.
+    #[test]
+    fn a_string_literal_is_a_single_token() {
+        assert_eq!(
+            sexpr_tokens(r#"(string "a ( b )")"#),
+            ["(", "string", r#""a ( b )""#, ")"]
+        );
+        assert_eq!(sexpr_tokens(r#""a \" b""#), [r#""a \" b""#]);
+        assert_eq!(
+            normalize_sexpr("(  call\n  f  a )"),
+            sexpr_tokens("(  call\n  f  a )").join(" ")
+        );
     }
 
     /// Julia accepts `do` only after a parenthesized call, and splices the clause

--- a/tests/ast-equivalence/known-drift.txt
+++ b/tests/ast-equivalence/known-drift.txt
@@ -1,0 +1,107 @@
+# Known AST-shape drift — slugs from the parser's oracle corpora whose program
+# shape the formatter moves, grouped under a rationale, in the style of
+# `crates/fatou-parser/tests/oracle/blocked.txt`. One slug per line.
+#
+# `policy:` groups are recorded formatter behavior that is value- and
+# type-preserving but visible in the JuliaSyntax projection. `DEFECT:` groups
+# are bugs this gate found; they are listed so the gate runs green while they
+# are fixed separately, not because the behavior is accepted. Entries are
+# staleness-checked — an entry fails until it is removed once its slug stops
+# drifting, and equally once its slug stops naming a case in either corpus.
+
+# ---------------------------------------------------------------------------
+# policy: `where T` canonicalizes to `where {T}`. Julia's `Expr` is identical
+# either way; only JuliaSyntax's surface tree records the braces. Asserted by
+# `crates/fatou-formatter/tests/fixtures/formatter/where_clauses/expected.jl`.
+anon_function_signature
+block_form_operand
+js-063e192a
+js-11e2e762
+js-12ef57ec
+js-41e2a5cf
+js-488a8833
+js-4a7ae664
+js-4eeda108
+js-6278bb20
+js-63fa1644
+js-964375a2
+js-bf71b3b1
+js-c4d48e55
+js-cbd92fc9
+js-cd3e3ee0
+js-d0103ba8
+js-e0aa726d
+parametric_types
+parenthesized_anonymous_function_parameters
+unicode_operator_call
+where_as_identifier
+where_precedence
+
+# DEFECT: the `where` brace canonicalization double-wraps a parameter list that
+# is already braced but does not project as `braces` — `x where {T S}` formats
+# to `x where {{T S}}` and `x where {y for y in ys}` to `x where {{y for y in
+# ys}}`. Both outputs are different programs (and the first no longer lowers).
+# This is why the `where` policy above is a listed exemption rather than a
+# normalization in `verify::ast_shape`: erasing the braces would hide this.
+js-1c86494f
+js-ee8d7fdd
+
+# policy: a top-level `;` separator is replaced by a line break, erasing the
+# `(toplevel-; ...)` grouping — `a; b` becomes two lines. Equivalent in a file;
+# `;` only suppresses output in the REPL, whose soft scope fatou does not model.
+# (The trailing `;` of `>:;` and of `a;;;b;;` survives, so the rewrite is not
+# uniform, but no listed case changes meaning.)
+bare_operator
+js-02079ffa
+js-3043c4a2
+js-35c649e9
+js-714d8a96
+js-8d65be34
+js-9b9946da
+js-acfc6b49
+toplevel_semicolon
+
+# DEFECT: a trailing `;` inside brackets is dropped, collapsing a concatenation
+# into a container literal — `[x;]` (`vcat`) becomes `[x]` (`vect`), `[;]`
+# becomes `[]`, `{x;}` becomes `{x}`. For a non-scalar element these are
+# different values: `[1:70;]` is a 70-element `Vector{Int}`, `[1:70]` a
+# 1-element `Vector{UnitRange{Int}}`. The typed forms are worse still —
+# `T[x;]` (`typed_vcat`) becomes `T[x]`, which projects as `ref`, i.e. indexing
+# `T` rather than constructing it.
+bracescat
+broadcast_bitshift
+js-3bdaee7b
+js-41bffcf8
+js-47310745
+js-939f51f9
+ncat
+typed_concat
+
+# DEFECT: dropping a trailing comma turns an operator *call* into a prefix
+# operator application — `+(a=1,)` (`(call + (= a 1))`, a keyword argument)
+# formats to `+(a = 1)` (`(call-pre + (= a 1))`, unary plus applied to an
+# assignment). Same for `<:(a,)`, `>:(a,)` and `.+(a,)`. Unlike the trailing
+# comma inside an ordinary call, this one is load-bearing.
+js-11eada5f
+js-70cde333
+js-729f9f07
+js-effed8f1
+type_operator_call
+unary_operator_call
+
+# DEFECT: whitespace between a macro's arguments is removed, changing arity —
+# `@foo a [1]` (two arguments, `a` and `[1]`) formats to `@foo a[1]` (one
+# argument, `a[1]`); likewise `@foo A {T}` -> `@foo A{T}` and `@foo g(x) [1]`.
+# For a macro the argument list is the input, so this rewrites the call.
+macro_space_args
+
+# DEFECT: a spaced unary minus is folded into the literal — `- 2` (`(call-pre -
+# 2)`) becomes the literal `-2`. Value-identical except at a type boundary:
+# `- 9223372036854775808` negates an `Int128` literal, while
+# `-9223372036854775808` is the `Int64` `typemin`.
+js-84685b8e
+
+# policy: numeric literal canonicalization (`.5` -> `0.5`, `2.` -> `2.0`,
+# `1f0` -> `1.0f0`). The projector renders a float's source spelling, so every
+# such row moves; each rewrite is value- and type-preserving.
+numeric_literals

--- a/tests/format_ast_equivalence.rs
+++ b/tests/format_ast_equivalence.rs
@@ -1,0 +1,174 @@
+//! `ast(x) == ast(format(x))` over the parser's corpora.
+//!
+//! [`fatou_formatter::verify::ast_shape`] says whether formatting preserved the
+//! program. `crates/fatou-formatter/tests/formatter.rs` applies it to the
+//! formatter's own 151 fixtures; this applies it to the ~1000 inputs the
+//! *parser* curates, which the formatter otherwise never runs on:
+//!
+//! - `crates/fatou-parser/tests/fixtures/oracle/<slug>/input.jl` — the pinned
+//!   JuliaSyntax corpus.
+//! - `crates/fatou-parser/tests/fixtures/oracle/juliasyntax.jsonl` — the 756
+//!   micro-cases harvested from JuliaSyntax's own `test/parser.jl`.
+//!
+//! Those corpora exist to pin *parser* shape, so they reach far more grammar
+//! than hand-authored formatter fixtures do — which is exactly why the formatter
+//! defects this check found live here. The check needs no `expected` file, so
+//! pointing it at them costs nothing.
+//!
+//! Cases outside the invariant's domain (no clean parse, or a projector
+//! sentinel) are skipped by `ast_shape` itself; the corpora are full of
+//! deliberate error-recovery inputs, and formatting an error tree has no defined
+//! equivalence. A case whose *formatted output* stops parsing is a failure, not
+//! a skip.
+//!
+//! `tests/ast-equivalence/known-drift.txt` lists the slugs whose shape the
+//! formatter is known to move, grouped under a rationale comment, in the style
+//! of `crates/fatou-parser/tests/oracle/blocked.txt`. Entries are checked for
+//! staleness: an entry fails until it is removed once its slug stops drifting,
+//! and equally once its slug stops being checked at all. The corpora are
+//! regenerated — `js-*` slugs are content-derived hashes — so an entry whose
+//! case was renamed away would otherwise linger unexamined forever.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use fatou::parser::parse;
+use fatou_formatter::format;
+use fatou_formatter::verify::ast_shape;
+
+const DIR_CORPUS: &str = "crates/fatou-parser/tests/fixtures/oracle";
+const JS_CORPUS: &str = "crates/fatou-parser/tests/fixtures/oracle/juliasyntax.jsonl";
+const KNOWN_DRIFT: &str = "tests/ast-equivalence/known-drift.txt";
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn known_drift() -> BTreeSet<String> {
+    let Ok(content) = fs::read_to_string(repo_path(KNOWN_DRIFT)) else {
+        return BTreeSet::new();
+    };
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+/// `(slug, source)` for every case in both corpora.
+fn cases() -> Vec<(String, String)> {
+    let mut cases = Vec::new();
+
+    let dir = repo_path(DIR_CORPUS);
+    for entry in fs::read_dir(&dir).expect("read oracle corpus dir") {
+        let entry = entry.expect("read corpus entry");
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let input = entry.path().join("input.jl");
+        if !input.is_file() {
+            continue;
+        }
+        cases.push((
+            entry.file_name().to_string_lossy().to_string(),
+            fs::read_to_string(&input).expect("read input.jl"),
+        ));
+    }
+
+    if let Ok(content) = fs::read_to_string(repo_path(JS_CORPUS)) {
+        for line in content.lines().filter(|l| !l.trim().is_empty()) {
+            let v: serde_json::Value =
+                serde_json::from_str(line).expect("parse juliasyntax.jsonl line");
+            cases.push((
+                v["slug"].as_str().expect("slug").to_string(),
+                v["input"].as_str().expect("input").to_string(),
+            ));
+        }
+    }
+
+    cases.sort();
+    cases
+}
+
+#[test]
+fn formatting_preserves_ast_shape_over_parser_corpora() {
+    let known = known_drift();
+    let (mut drifted, mut unparsable, mut unprojectable) = (Vec::new(), Vec::new(), Vec::new());
+    let mut stale = Vec::new();
+    let mut exercised = BTreeSet::new();
+    let (mut checked, mut skipped) = (0usize, 0usize);
+
+    for (slug, source) in cases() {
+        let Some(before) = ast_shape(&source) else {
+            skipped += 1;
+            continue; // out of domain: no clean parse, or a projector sentinel
+        };
+        let Ok(formatted) = format(&source) else {
+            unparsable.push(format!(
+                "{slug}: format() errored on a cleanly-parsing input"
+            ));
+            continue;
+        };
+        checked += 1;
+        exercised.insert(slug.clone());
+
+        match ast_shape(&formatted) {
+            // The source parsed cleanly and projected, so a formatted text with
+            // no shape is the formatter's doing — but `ast_shape` folds two
+            // causes into `None`, and they point at different code. Reparse to
+            // tell them apart instead of naming the more likely one.
+            None if !parse(&formatted).diagnostics.is_empty() => {
+                unparsable.push(format!("{slug}: {source:?} -> {formatted:?}"));
+            }
+            None => unprojectable.push(format!("{slug}: {source:?} -> {formatted:?}")),
+            Some(after) if after == before => {
+                if known.contains(&slug) {
+                    stale.push(format!("{slug} (no longer drifts)"));
+                }
+            }
+            Some(after) => {
+                if !known.contains(&slug) {
+                    drifted.push(format!(
+                        "{slug}: {source:?} -> {formatted:?}\n     before: {before}\n     after:  {after}"
+                    ));
+                }
+            }
+        }
+    }
+
+    // An entry no case reached is as stale as one that stopped drifting: the
+    // slug was renamed or dropped, and the exemption now hides nothing.
+    stale.extend(
+        known
+            .difference(&exercised)
+            .map(|slug| format!("{slug} (matches no case in either corpus)")),
+    );
+
+    assert!(
+        checked > 500,
+        "only {checked} cases were in domain ({skipped} skipped) — the corpora look truncated"
+    );
+    assert!(
+        unparsable.is_empty(),
+        "formatted output no longer parses cleanly for:\n  - {}",
+        unparsable.join("\n  - ")
+    );
+    assert!(
+        unprojectable.is_empty(),
+        "formatted output parses but no longer projects — the formatter produced \
+         a construct the projector cannot render, so this case is unverifiable:\n  - {}",
+        unprojectable.join("\n  - ")
+    );
+    assert!(
+        stale.is_empty(),
+        "known-drift.txt entries no longer apply — remove them:\n  - {}",
+        stale.join("\n  - ")
+    );
+    assert!(
+        drifted.is_empty(),
+        "formatting changed the program shape for:\n  - {}",
+        drifted.join("\n  - ")
+    );
+}


### PR DESCRIPTION
Idempotence and clean reparse are both local invariants: neither says the
formatted output still *means* what the input meant. `verify::ast_shape`
closes that gap, giving the formatter a comparable value for
`ast(x) == ast(format(x))`.

The shape reuses the JuliaSyntax s-expression projection rather than adding
a third model: it is the one projection in the workspace validated
differentially against real Julia, and the typed AST is a read-only view
over the trivia-bearing CST, not comparable. The normalization on top erases
exactly one surface fact the formatter is licensed to change — JuliaSyntax's
trailing-comma flag, which the formatter sets whenever it explodes an
argument list. `where T` -> `where {T}`, `toplevel-;` erasure, and literal
canonicalization are left visible: each erasure that would hide them would
also hide a real defect, so they are recorded as known-drift entries instead.

`formatter_preserves_ast_shape` applies it to every fixture, gated or not.
Seven drift, each listed with its reason; entries are staleness-checked, so a
fixed defect cannot leave its exemption behind. Two of the seven are bugs
the gate found: `[1:70;]` formatting to `[1:70]` (vcat becomes vect), and
`0x1_2` to `0x01_2` (the zero-padder counts `_` as a digit, widening a UInt8
literal to UInt16).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015uMhB8bPBVuFoUt5cPzJKh