### PR TITLE
chore(release): v0.18.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,26 +1,26 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "141edd9a51a5f8c15800047d83305a44c5784ad1",
+  "baseline-sha": "4079869f3edd660ef8c5a7afcae06b283bbb37ba",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.5.0",
-      "tag": "fatou-formatter-v0.5.0"
+      "version": "0.6.0",
+      "tag": "fatou-formatter-v0.6.0"
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.5.0",
-      "tag": "fatou-parser-v0.5.0"
+      "version": "0.6.0",
+      "tag": "fatou-parser-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.17.0",
-      "tag": "fatou-code-v0.17.0"
+      "version": "0.18.0",
+      "tag": "fatou-code-v0.18.0"
     },
     {
       "path": "editors/zed",
@@ -31,18 +31,23 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.5.0",
-      "tag": "fatou-formatter-v0.5.0"
+      "version": "0.6.0",
+      "tag": "fatou-formatter-v0.6.0"
+    },
+    {
+      "path": "crates/fatou-parser",
+      "version": "0.6.0",
+      "tag": "fatou-parser-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.17.0",
-      "tag": "fatou-code-v0.17.0"
+      "version": "0.18.0",
+      "tag": "fatou-code-v0.18.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/fatou/compare/v0.17.0...v0.18.0) (2026-08-27)
+
+### Features
+- **lint:** check Julia documentation ([`1baa96a`](https://github.com/jolars/fatou/commit/1baa96a6319d25fb26aa5f0f2789ec02ff4bf8a3))
+- **lsp:** add docstring language features ([`97f9086`](https://github.com/jolars/fatou/commit/97f90860fa7bcc2879b610b3996b93a1411e256e))
+- index documentation semantically ([`5d4ec9c`](https://github.com/jolars/fatou/commit/5d4ec9c5bc451b5a790d92e2292d554b8ca3fffe))
+- **lint:** add Test rule bundle ([`fc0759f`](https://github.com/jolars/fatou/commit/fc0759fdb27b1823874c8f9a4fb981984fd8f204))
+- **parser:** parse imported macro aliases ([`ce0eb13`](https://github.com/jolars/fatou/commit/ce0eb13bac8c1705a7afe173610b548e1842ef67))
+
+### Bug Fixes
+- **lsp:** correct documentation completion, definition, and painting ([`63b429a`](https://github.com/jolars/fatou/commit/63b429ace9953c6bcecbb8adb00458c54a73d9fe))
+- **lint:** make the docstring reference rule opt-in ([`3f1bbe8`](https://github.com/jolars/fatou/commit/3f1bbe8a9a5c5b0f129345a89f2c106e3205db73))
+- **formatter:** preserve unary numeric calls ([`09320a9`](https://github.com/jolars/fatou/commit/09320a9e1b847ce2863031955f0ccb3f5efd36fc))
+- **formatter:** preserve operator call commas ([`cbe6d31`](https://github.com/jolars/fatou/commit/cbe6d31edd16a9411e8741493aaa00e70b0968a7))
+- **formatter:** preserve trailing semicolons ([`3e9a47f`](https://github.com/jolars/fatou/commit/3e9a47f5495848d69b597dcd52e448b00e202f78))
+- **formatter:** preserve macro argument gaps ([`26297a8`](https://github.com/jolars/fatou/commit/26297a8b4d67fe51270467467dbae54af544129a))
+- **formatter:** preserve where brace shapes ([`52d7fbc`](https://github.com/jolars/fatou/commit/52d7fbc3d256fec4e42d3b1da368c87f3460f1a9))
+- **formatter:** preserve grouped hex width ([`05b2f72`](https://github.com/jolars/fatou/commit/05b2f7237dd4f0982028928e9798d9b65db11219)), closes [#92](https://github.com/jolars/fatou/issues/92)
+
+### Dependencies
+- updated crates/fatou-formatter to v0.6.0
+- updated crates/fatou-parser to v0.6.0
+
 ## [0.17.0](https://github.com/jolars/fatou/compare/v0.16.0...v0.17.0) (2026-08-26)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -530,7 +530,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "insta",
@@ -823,9 +823,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -49,8 +49,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.5.0" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.5.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.6.0" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.6.0" }
 globset = "0.4.18"
 ignore = "0.4.26"
 log = { version = "0.4.32", features = ["release_max_level_info"] }

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.5.0...fatou-formatter-v0.6.0) (2026-08-27)
+
+### Features
+- **formatter:** verify formatting preserves the program with ast_shape ([`3f4e9c9`](https://github.com/jolars/fatou/commit/3f4e9c93d671071b529089ed9c9cedc81b44f9a1))
+
+### Bug Fixes
+- **formatter:** preserve unary numeric calls ([`09320a9`](https://github.com/jolars/fatou/commit/09320a9e1b847ce2863031955f0ccb3f5efd36fc))
+- **formatter:** preserve operator call commas ([`cbe6d31`](https://github.com/jolars/fatou/commit/cbe6d31edd16a9411e8741493aaa00e70b0968a7))
+- **formatter:** preserve trailing semicolons ([`3e9a47f`](https://github.com/jolars/fatou/commit/3e9a47f5495848d69b597dcd52e448b00e202f78))
+- **formatter:** preserve macro argument gaps ([`26297a8`](https://github.com/jolars/fatou/commit/26297a8b4d67fe51270467467dbae54af544129a))
+- **formatter:** preserve where brace shapes ([`52d7fbc`](https://github.com/jolars/fatou/commit/52d7fbc3d256fec4e42d3b1da368c87f3460f1a9))
+- **formatter:** preserve grouped hex width ([`05b2f72`](https://github.com/jolars/fatou/commit/05b2f7237dd4f0982028928e9798d9b65db11219)), closes [#92](https://github.com/jolars/fatou/issues/92)
+
+### Dependencies
+- updated crates/fatou-parser to v0.6.0
+
 ## [0.5.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.4.0...fatou-formatter-v0.5.0) (2026-08-26)
 
 ### Features

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.5.0" }
+fatou-parser = { path = "../fatou-parser", version = "0.6.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.5.0...fatou-parser-v0.6.0) (2026-08-27)
+
+### Features
+- **parser:** expose heading anchor slugs ([`8a36261`](https://github.com/jolars/fatou/commit/8a362615e8785dfcd65927ca1bb481c0489d3953))
+- **parser:** map source offsets into docs ([`8a17a9b`](https://github.com/jolars/fatou/commit/8a17a9bbb201fcf1ac57dcc4796345e52b652193))
+- **parser:** parse Julia documentation ([`3af07ba`](https://github.com/jolars/fatou/commit/3af07ba9a12b8dbbe4542b04f95d5eb32bb9be5a))
+- **parser:** expose static docstrings ([`344cd96`](https://github.com/jolars/fatou/commit/344cd96474912d9eef4bbb0f7bc0ef77b9e0d083))
+- **parser:** parse imported macro aliases ([`ce0eb13`](https://github.com/jolars/fatou/commit/ce0eb13bac8c1705a7afe173610b548e1842ef67))
+
+### Bug Fixes
+- **parser:** parse code blocks in list items ([`2cd1d8f`](https://github.com/jolars/fatou/commit/2cd1d8fe1ef659e655f2d0d4e132657511c0ba97))
+- **parser:** match Julia on setext and admonition titles ([`35ea9d4`](https://github.com/jolars/fatou/commit/35ea9d4a064de76a47a6fdd579cf9de9ca5603d5))
+- **parser:** read a link's own destination ([`f0aab27`](https://github.com/jolars/fatou/commit/f0aab27f0d730955762c7e4c8c91e9e1ca9720e1))
+
+### Performance Improvements
+- **parser:** store docstring source maps as runs ([`7a166b1`](https://github.com/jolars/fatou/commit/7a166b1e2fc24bf2516311f11241bb3ee39ae088))
+
 ## [0.5.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.4.1...fatou-parser-v0.5.0) (2026-08-25)
 
 ### Features

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/fatou/compare/fatou-code-v0.17.0...fatou-code-v0.18.0) (2026-08-27)
+
+### Dependencies
+- updated fatou to v0.18.0
+
 ## [0.17.0](https://github.com/jolars/fatou/compare/fatou-code-v0.16.0...fatou-code-v0.17.0) (2026-08-26)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         fatou = pkgs.rustPlatform.buildRustPackage {
           pname = "fatou";
-          version = "0.17.0";
+          version = "0.18.0";
 
           src = ./.;
 

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.17.0",
-    "@fatou-cli/linux-arm64-gnu": "0.17.0",
-    "@fatou-cli/linux-x64-musl": "0.17.0",
-    "@fatou-cli/linux-arm64-musl": "0.17.0",
-    "@fatou-cli/darwin-x64": "0.17.0",
-    "@fatou-cli/darwin-arm64": "0.17.0",
-    "@fatou-cli/win32-x64": "0.17.0",
-    "@fatou-cli/win32-arm64": "0.17.0"
+    "@fatou-cli/linux-x64-gnu": "0.18.0",
+    "@fatou-cli/linux-arm64-gnu": "0.18.0",
+    "@fatou-cli/linux-x64-musl": "0.18.0",
+    "@fatou-cli/linux-arm64-musl": "0.18.0",
+    "@fatou-cli/darwin-x64": "0.18.0",
+    "@fatou-cli/darwin-arm64": "0.18.0",
+    "@fatou-cli/win32-x64": "0.18.0",
+    "@fatou-cli/win32-arm64": "0.18.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.18.0](https://github.com/jolars/fatou/compare/v0.17.0...v0.18.0) (2026-08-27)

### Features
- **lint:** check Julia documentation ([`1baa96a`](https://github.com/jolars/fatou/commit/1baa96a6319d25fb26aa5f0f2789ec02ff4bf8a3))
- **lsp:** add docstring language features ([`97f9086`](https://github.com/jolars/fatou/commit/97f90860fa7bcc2879b610b3996b93a1411e256e))
- index documentation semantically ([`5d4ec9c`](https://github.com/jolars/fatou/commit/5d4ec9c5bc451b5a790d92e2292d554b8ca3fffe))
- **lint:** add Test rule bundle ([`fc0759f`](https://github.com/jolars/fatou/commit/fc0759fdb27b1823874c8f9a4fb981984fd8f204))
- **parser:** parse imported macro aliases ([`ce0eb13`](https://github.com/jolars/fatou/commit/ce0eb13bac8c1705a7afe173610b548e1842ef67))

### Bug Fixes
- **lsp:** correct documentation completion, definition, and painting ([`63b429a`](https://github.com/jolars/fatou/commit/63b429ace9953c6bcecbb8adb00458c54a73d9fe))
- **lint:** make the docstring reference rule opt-in ([`3f1bbe8`](https://github.com/jolars/fatou/commit/3f1bbe8a9a5c5b0f129345a89f2c106e3205db73))
- **formatter:** preserve unary numeric calls ([`09320a9`](https://github.com/jolars/fatou/commit/09320a9e1b847ce2863031955f0ccb3f5efd36fc))
- **formatter:** preserve operator call commas ([`cbe6d31`](https://github.com/jolars/fatou/commit/cbe6d31edd16a9411e8741493aaa00e70b0968a7))
- **formatter:** preserve trailing semicolons ([`3e9a47f`](https://github.com/jolars/fatou/commit/3e9a47f5495848d69b597dcd52e448b00e202f78))
- **formatter:** preserve macro argument gaps ([`26297a8`](https://github.com/jolars/fatou/commit/26297a8b4d67fe51270467467dbae54af544129a))
- **formatter:** preserve where brace shapes ([`52d7fbc`](https://github.com/jolars/fatou/commit/52d7fbc3d256fec4e42d3b1da368c87f3460f1a9))
- **formatter:** preserve grouped hex width ([`05b2f72`](https://github.com/jolars/fatou/commit/05b2f7237dd4f0982028928e9798d9b65db11219)), closes [#92](https://github.com/jolars/fatou/issues/92)

### Dependencies
- updated crates/fatou-formatter to v0.6.0
- updated crates/fatou-parser to v0.6.0

## [crates/fatou-formatter: 0.6.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.5.0...fatou-formatter-v0.6.0) (2026-08-27)

### Features
- **formatter:** verify formatting preserves the program with ast_shape ([`3f4e9c9`](https://github.com/jolars/fatou/commit/3f4e9c93d671071b529089ed9c9cedc81b44f9a1))

### Bug Fixes
- **formatter:** preserve unary numeric calls ([`09320a9`](https://github.com/jolars/fatou/commit/09320a9e1b847ce2863031955f0ccb3f5efd36fc))
- **formatter:** preserve operator call commas ([`cbe6d31`](https://github.com/jolars/fatou/commit/cbe6d31edd16a9411e8741493aaa00e70b0968a7))
- **formatter:** preserve trailing semicolons ([`3e9a47f`](https://github.com/jolars/fatou/commit/3e9a47f5495848d69b597dcd52e448b00e202f78))
- **formatter:** preserve macro argument gaps ([`26297a8`](https://github.com/jolars/fatou/commit/26297a8b4d67fe51270467467dbae54af544129a))
- **formatter:** preserve where brace shapes ([`52d7fbc`](https://github.com/jolars/fatou/commit/52d7fbc3d256fec4e42d3b1da368c87f3460f1a9))
- **formatter:** preserve grouped hex width ([`05b2f72`](https://github.com/jolars/fatou/commit/05b2f7237dd4f0982028928e9798d9b65db11219)), closes [#92](https://github.com/jolars/fatou/issues/92)

### Dependencies
- updated crates/fatou-parser to v0.6.0

## [crates/fatou-parser: 0.6.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.5.0...fatou-parser-v0.6.0) (2026-08-27)

### Features
- **parser:** expose heading anchor slugs ([`8a36261`](https://github.com/jolars/fatou/commit/8a362615e8785dfcd65927ca1bb481c0489d3953))
- **parser:** map source offsets into docs ([`8a17a9b`](https://github.com/jolars/fatou/commit/8a17a9bbb201fcf1ac57dcc4796345e52b652193))
- **parser:** parse Julia documentation ([`3af07ba`](https://github.com/jolars/fatou/commit/3af07ba9a12b8dbbe4542b04f95d5eb32bb9be5a))
- **parser:** expose static docstrings ([`344cd96`](https://github.com/jolars/fatou/commit/344cd96474912d9eef4bbb0f7bc0ef77b9e0d083))
- **parser:** parse imported macro aliases ([`ce0eb13`](https://github.com/jolars/fatou/commit/ce0eb13bac8c1705a7afe173610b548e1842ef67))

### Bug Fixes
- **parser:** parse code blocks in list items ([`2cd1d8f`](https://github.com/jolars/fatou/commit/2cd1d8fe1ef659e655f2d0d4e132657511c0ba97))
- **parser:** match Julia on setext and admonition titles ([`35ea9d4`](https://github.com/jolars/fatou/commit/35ea9d4a064de76a47a6fdd579cf9de9ca5603d5))
- **parser:** read a link's own destination ([`f0aab27`](https://github.com/jolars/fatou/commit/f0aab27f0d730955762c7e4c8c91e9e1ca9720e1))

### Performance Improvements
- **parser:** store docstring source maps as runs ([`7a166b1`](https://github.com/jolars/fatou/commit/7a166b1e2fc24bf2516311f11241bb3ee39ae088))

## [editors/code: 0.18.0](https://github.com/jolars/fatou/compare/fatou-code-v0.17.0...fatou-code-v0.18.0) (2026-08-27)

### Dependencies
- updated fatou to v0.18.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).