### PR TITLE
chore(release): v0.19.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,26 +1,36 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "4079869f3edd660ef8c5a7afcae06b283bbb37ba",
+  "baseline-sha": "26bc83a6836268e91062efe167ba8b8a1b556ab9",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "0.19.0",
+      "tag": "v0.19.0",
+      "dependencies": [
+        "crates/fatou-formatter",
+        "crates/fatou-parser"
+      ]
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.6.0",
-      "tag": "fatou-formatter-v0.6.0"
+      "version": "0.7.0",
+      "tag": "fatou-formatter-v0.7.0",
+      "dependencies": [
+        "crates/fatou-parser"
+      ]
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.6.0",
-      "tag": "fatou-parser-v0.6.0"
+      "version": "0.7.0",
+      "tag": "fatou-parser-v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.18.0",
-      "tag": "fatou-code-v0.18.0"
+      "version": "0.19.0",
+      "tag": "fatou-code-v0.19.0",
+      "dependencies": [
+        "."
+      ]
     },
     {
       "path": "editors/zed",
@@ -31,23 +41,33 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "0.19.0",
+      "tag": "v0.19.0",
+      "dependencies": [
+        "crates/fatou-formatter",
+        "crates/fatou-parser"
+      ]
     },
     {
       "path": "crates/fatou-formatter",
-      "version": "0.6.0",
-      "tag": "fatou-formatter-v0.6.0"
+      "version": "0.7.0",
+      "tag": "fatou-formatter-v0.7.0",
+      "dependencies": [
+        "crates/fatou-parser"
+      ]
     },
     {
       "path": "crates/fatou-parser",
-      "version": "0.6.0",
-      "tag": "fatou-parser-v0.6.0"
+      "version": "0.7.0",
+      "tag": "fatou-parser-v0.7.0"
     },
     {
       "path": "editors/code",
-      "version": "0.18.0",
-      "tag": "fatou-code-v0.18.0"
+      "version": "0.19.0",
+      "tag": "fatou-code-v0.19.0",
+      "dependencies": [
+        "."
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/fatou/compare/v0.18.0...v0.19.0) (2026-09-10)
+
+### Features
+- **lsp:** show registry versions and dependency upgrades ([`26bc83a`](https://github.com/jolars/fatou/commit/26bc83a6836268e91062efe167ba8b8a1b556ab9))
+- **lsp:** update dependency bounds in `Project.toml` ([`bad32ae`](https://github.com/jolars/fatou/commit/bad32aedd3aec09a3e015f54db021b6f4689358a))
+- **config:** publish JSON schema ([`2c2ed0f`](https://github.com/jolars/fatou/commit/2c2ed0f9e479f3e617a73ac635dcf83c225461dc))
+- **cli:** add safe formatting mode ([`150ea3d`](https://github.com/jolars/fatou/commit/150ea3df9a3b5847138256b76cef7245445cf984)), closes [#93](https://github.com/jolars/fatou/issues/93)
+
+### Dependencies
+- updated crates/fatou-formatter to v0.7.0
+- updated crates/fatou-parser to v0.7.0
+
 ## [0.18.0](https://github.com/jolars/fatou/compare/v0.17.0...v0.18.0) (2026-08-27)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "borrow-or-share"
@@ -219,9 +219,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -306,7 +306,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -351,9 +351,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.4"
+version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+checksum = "e96a4956774c13c126a8b5af4daa79384f4d826534c95a02d76afb39e2ab64e3"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -416,18 +416,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -435,27 +435,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -529,7 +529,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -629,7 +629,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fatou"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "annotate-snippets",
  "clap",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-formatter"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "fatou-parser",
  "rowan",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "fatou-parser"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "insta",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "a596f1b20ed2cc5ecac41a164aaebc7258057060f06c0cf7a2ba3991ee7990fb"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
@@ -1154,9 +1154,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -1406,9 +1406,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -1491,7 +1491,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1617,7 +1617,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1670,7 +1670,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1704,7 +1704,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1746,7 +1746,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1757,7 +1757,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1781,7 +1781,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smol_str"
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1963,7 +1963,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1988,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2003,9 +2003,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2166,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2176,22 +2176,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2285,18 +2285,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2354,7 +2354,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "fatou"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -49,8 +49,8 @@ clap = { version = "4.6.1", features = ["derive"] }
 crossbeam-channel = "0.5.16"
 dirs = "6.0.0"
 env_logger = "0.11.10"
-fatou-formatter = { path = "crates/fatou-formatter", version = "0.6.0" }
-fatou-parser = { path = "crates/fatou-parser", version = "0.6.0" }
+fatou-formatter = { path = "crates/fatou-formatter", version = "0.7.0" }
+fatou-parser = { path = "crates/fatou-parser", version = "0.7.0" }
 flate2 = "1.1.10"
 globset = "0.4.18"
 ignore = "0.4.26"

--- a/crates/fatou-formatter/CHANGELOG.md
+++ b/crates/fatou-formatter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.6.0...fatou-formatter-v0.7.0) (2026-09-10)
+
+### Features
+- **cli:** add safe formatting mode ([`150ea3d`](https://github.com/jolars/fatou/commit/150ea3df9a3b5847138256b76cef7245445cf984)), closes [#93](https://github.com/jolars/fatou/issues/93)
+- **formatter:** add verified formatting ([`874cf57`](https://github.com/jolars/fatou/commit/874cf57ceb09609670fab5054693cd951c62d3e8)), refs [#93](https://github.com/jolars/fatou/issues/93)
+
+### Dependencies
+- updated crates/fatou-parser to v0.7.0
+
 ## [0.6.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.5.0...fatou-formatter-v0.6.0) (2026-08-27)
 
 ### Features

--- a/crates/fatou-formatter/Cargo.toml
+++ b/crates/fatou-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-formatter"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["julia", "formatter"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-fatou-parser = { path = "../fatou-parser", version = "0.6.0" }
+fatou-parser = { path = "../fatou-parser", version = "0.7.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/fatou-parser/CHANGELOG.md
+++ b/crates/fatou-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.6.0...fatou-parser-v0.7.0) (2026-09-10)
+
+### Features
+- **cli:** add safe formatting mode ([`150ea3d`](https://github.com/jolars/fatou/commit/150ea3df9a3b5847138256b76cef7245445cf984)), closes [#93](https://github.com/jolars/fatou/issues/93)
+
 ## [0.6.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.5.0...fatou-parser-v0.6.0) (2026-08-27)
 
 ### Features

--- a/crates/fatou-parser/Cargo.toml
+++ b/crates/fatou-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatou-parser"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/docs/doc-utils/Cargo.lock
+++ b/docs/doc-utils/Cargo.lock
@@ -41,9 +41,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -179,7 +179,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/fatou/compare/fatou-code-v0.18.0...fatou-code-v0.19.0) (2026-09-10)
+
+### Dependencies
+- updated fatou to v0.19.0
+
 ## [0.18.0](https://github.com/jolars/fatou/compare/fatou-code-v0.17.0...fatou-code-v0.18.0) (2026-08-27)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "fatou",
   "displayName": "Fatou",
   "description": "Julia language server, formatter, and linter",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "cfg-if"
@@ -55,7 +55,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -66,12 +66,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -145,7 +146,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -310,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -352,9 +353,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -452,7 +453,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -482,9 +483,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "spdx"
@@ -514,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -819,8 +820,14 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         fatou = pkgs.rustPlatform.buildRustPackage {
           pname = "fatou";
-          version = "0.18.0";
+          version = "0.19.0";
 
           src = ./.;
 

--- a/npm/fatou-cli/package.json
+++ b/npm/fatou-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fatou-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A language server, formatter, and linter for Julia",
   "keywords": [
     "julia",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@fatou-cli/linux-x64-gnu": "0.18.0",
-    "@fatou-cli/linux-arm64-gnu": "0.18.0",
-    "@fatou-cli/linux-x64-musl": "0.18.0",
-    "@fatou-cli/linux-arm64-musl": "0.18.0",
-    "@fatou-cli/darwin-x64": "0.18.0",
-    "@fatou-cli/darwin-arm64": "0.18.0",
-    "@fatou-cli/win32-x64": "0.18.0",
-    "@fatou-cli/win32-arm64": "0.18.0"
+    "@fatou-cli/linux-x64-gnu": "0.19.0",
+    "@fatou-cli/linux-arm64-gnu": "0.19.0",
+    "@fatou-cli/linux-x64-musl": "0.19.0",
+    "@fatou-cli/linux-arm64-musl": "0.19.0",
+    "@fatou-cli/darwin-x64": "0.19.0",
+    "@fatou-cli/darwin-arm64": "0.19.0",
+    "@fatou-cli/win32-x64": "0.19.0",
+    "@fatou-cli/win32-arm64": "0.19.0"
   }
 }


### PR DESCRIPTION
## [fatou: 0.19.0](https://github.com/jolars/fatou/compare/v0.18.0...v0.19.0) (2026-09-10)

### Features
- **lsp:** show registry versions and dependency upgrades ([`26bc83a`](https://github.com/jolars/fatou/commit/26bc83a6836268e91062efe167ba8b8a1b556ab9))
- **lsp:** update dependency bounds in `Project.toml` ([`bad32ae`](https://github.com/jolars/fatou/commit/bad32aedd3aec09a3e015f54db021b6f4689358a))
- **config:** publish JSON schema ([`2c2ed0f`](https://github.com/jolars/fatou/commit/2c2ed0f9e479f3e617a73ac635dcf83c225461dc))
- **cli:** add safe formatting mode ([`150ea3d`](https://github.com/jolars/fatou/commit/150ea3df9a3b5847138256b76cef7245445cf984)), closes [#93](https://github.com/jolars/fatou/issues/93)

### Dependencies
- updated crates/fatou-formatter to v0.7.0
- updated crates/fatou-parser to v0.7.0

## [crates/fatou-formatter: 0.7.0](https://github.com/jolars/fatou/compare/fatou-formatter-v0.6.0...fatou-formatter-v0.7.0) (2026-09-10)

### Features
- **cli:** add safe formatting mode ([`150ea3d`](https://github.com/jolars/fatou/commit/150ea3df9a3b5847138256b76cef7245445cf984)), closes [#93](https://github.com/jolars/fatou/issues/93)
- **formatter:** add verified formatting ([`874cf57`](https://github.com/jolars/fatou/commit/874cf57ceb09609670fab5054693cd951c62d3e8)), refs [#93](https://github.com/jolars/fatou/issues/93)

### Dependencies
- updated crates/fatou-parser to v0.7.0

## [crates/fatou-parser: 0.7.0](https://github.com/jolars/fatou/compare/fatou-parser-v0.6.0...fatou-parser-v0.7.0) (2026-09-10)

### Features
- **cli:** add safe formatting mode ([`150ea3d`](https://github.com/jolars/fatou/commit/150ea3df9a3b5847138256b76cef7245445cf984)), closes [#93](https://github.com/jolars/fatou/issues/93)

## [editors/code: 0.19.0](https://github.com/jolars/fatou/compare/fatou-code-v0.18.0...fatou-code-v0.19.0) (2026-09-10)

### Dependencies
- updated fatou to v0.19.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).